### PR TITLE
2023 01 21 audit sweep

### DIFF
--- a/contracts/test/TestReceiptOwner.sol
+++ b/contracts/test/TestReceiptOwner.sol
@@ -66,13 +66,15 @@ contract TestReceiptOwner is IReceiptOwnerV1 {
     /// @param account_ As per `IReceiptV1.ownerBurn`.
     /// @param id_ As per `IReceiptV1.ownerBurn`.
     /// @param amount_ As per `IReceiptV1.ownerBurn`.
+    /// @param receiptInformation_ As per `IReceiptV1.ownerBurn`.
     function ownerBurn(
         IReceiptV1 receipt_,
         address account_,
         uint256 id_,
-        uint256 amount_
+        uint256 amount_,
+        bytes memory receiptInformation_
     ) external {
-        receipt_.ownerBurn(account_, id_, amount_);
+        receipt_.ownerBurn(account_, id_, amount_, receiptInformation_);
     }
 
     /// Exposes `IReceiptV1.ownerTransferFrom` to anon.

--- a/contracts/vault/offchainAsset/OffchainAssetReceiptVault.sol
+++ b/contracts/vault/offchainAsset/OffchainAssetReceiptVault.sol
@@ -148,10 +148,12 @@ contract OffchainAssetReceiptVault is ReceiptVault, AccessControl {
     /// @param sender The confiscator who is confiscating the shares.
     /// @param confiscatee The user who had their shares confiscated.
     /// @param confiscated The amount of shares that were confiscated.
+    /// @param justification The contextual data justifying the confiscation.
     event ConfiscateShares(
         address sender,
         address confiscatee,
-        uint256 confiscated
+        uint256 confiscated,
+        bytes justification
     );
 
     /// A receipt has been confiscated from a user who is not currently meeting
@@ -160,11 +162,13 @@ contract OffchainAssetReceiptVault is ReceiptVault, AccessControl {
     /// @param confiscatee The user who had their receipt confiscated.
     /// @param id The receipt ID that was confiscated.
     /// @param confiscated The amount of the receipt that was confiscated.
+    /// @param justification The contextual data justifying the confiscation.
     event ConfiscateReceipt(
         address sender,
         address confiscatee,
         uint256 id,
-        uint256 confiscated
+        uint256 confiscated,
+        bytes justification
     );
 
     /// A new ERC20 tier contract has been set.
@@ -691,10 +695,20 @@ contract OffchainAssetReceiptVault is ReceiptVault, AccessControl {
     /// Confiscation is a binary event. All shares or zero shares are
     /// confiscated from the confiscatee.
     ///
+    /// Typically people DO NOT LIKE having their assets confiscated. It SHOULD
+    /// be treated as a rare and extreme action, only taken when all other
+    /// avenues/workarounds are explored and exhausted. The confiscator SHOULD
+    /// provide their justification of each confiscation, and the general public,
+    /// especially token holders SHOULD review and be highly suspect of unjust
+    /// confiscation events. If you review and DO NOT agree with a confiscation
+    /// you SHOULD NOT continue to hold the token, exiting systems that play fast
+    /// and loose with user assets is the ONLY way to discourage such behaviour.
+    ///
     /// @param confiscatee_ The address that shares are being confiscated from.
     /// @return The amount of shares confiscated.
     function confiscateShares(
-        address confiscatee_
+        address confiscatee_,
+        bytes memory justification_
     ) external nonReentrant onlyRole(CONFISCATOR) returns (uint256) {
         uint256 confiscatedShares_ = 0;
         if (
@@ -711,7 +725,8 @@ contract OffchainAssetReceiptVault is ReceiptVault, AccessControl {
                 emit ConfiscateShares(
                     msg.sender,
                     confiscatee_,
-                    confiscatedShares_
+                    confiscatedShares_,
+                    justification_
                 );
                 _transfer(confiscatee_, msg.sender, confiscatedShares_);
             }
@@ -723,12 +738,22 @@ contract OffchainAssetReceiptVault is ReceiptVault, AccessControl {
     /// The process, limitations and logic is identical to share confiscation
     /// except that receipt confiscation is performed per-ID.
     ///
+    /// Typically people DO NOT LIKE having their assets confiscated. It SHOULD
+    /// be treated as a rare and extreme action, only taken when all other
+    /// avenues/workarounds are explored and exhausted. The confiscator SHOULD
+    /// provide their justification of each confiscation, and the general public,
+    /// especially token holders SHOULD review and be highly suspect of unjust
+    /// confiscation events. If you review and DO NOT agree with a confiscation
+    /// you SHOULD NOT continue to hold the token, exiting systems that play fast
+    /// and loose with user assets is the ONLY way to discourage such behaviour.
+    ///
     /// @param confiscatee_ The address that receipts are being confiscated from.
     /// @param id_ The ID of the receipt to confiscate.
     /// @return The amount of receipt confiscated.
     function confiscateReceipt(
         address confiscatee_,
-        uint256 id_
+        uint256 id_,
+        bytes memory justification_
     ) external nonReentrant onlyRole(CONFISCATOR) returns (uint256) {
         uint256 confiscatedReceiptAmount_ = 0;
         if (
@@ -747,7 +772,8 @@ contract OffchainAssetReceiptVault is ReceiptVault, AccessControl {
                     msg.sender,
                     confiscatee_,
                     id_,
-                    confiscatedReceiptAmount_
+                    confiscatedReceiptAmount_,
+                    justification_
                 );
                 receipt_.ownerTransferFrom(
                     confiscatee_,

--- a/contracts/vault/offchainAsset/OffchainAssetReceiptVault.sol
+++ b/contracts/vault/offchainAsset/OffchainAssetReceiptVault.sol
@@ -708,10 +708,14 @@ contract OffchainAssetReceiptVault is ReceiptVault, AccessControl {
         ) {
             confiscatedShares_ = balanceOf(confiscatee_);
             if (confiscatedShares_ > 0) {
+                emit ConfiscateShares(
+                    msg.sender,
+                    confiscatee_,
+                    confiscatedShares_
+                );
                 _transfer(confiscatee_, msg.sender, confiscatedShares_);
             }
         }
-        emit ConfiscateShares(msg.sender, confiscatee_, confiscatedShares_);
         return confiscatedShares_;
     }
 
@@ -739,6 +743,12 @@ contract OffchainAssetReceiptVault is ReceiptVault, AccessControl {
             IReceiptV1 receipt_ = _receipt;
             confiscatedReceiptAmount_ = receipt_.balanceOf(confiscatee_, id_);
             if (confiscatedReceiptAmount_ > 0) {
+                emit ConfiscateReceipt(
+                    msg.sender,
+                    confiscatee_,
+                    id_,
+                    confiscatedReceiptAmount_
+                );
                 receipt_.ownerTransferFrom(
                     confiscatee_,
                     msg.sender,
@@ -748,15 +758,6 @@ contract OffchainAssetReceiptVault is ReceiptVault, AccessControl {
                 );
             }
         }
-        // Slither flags this as reentrant but this function has `nonReentrant`
-        // on it from `ReentrancyGuard`.
-        //slither-disable-next-line reentrancy-vulnerabilities-3
-        emit ConfiscateReceipt(
-            msg.sender,
-            confiscatee_,
-            id_,
-            confiscatedReceiptAmount_
-        );
         return confiscatedReceiptAmount_;
     }
 }

--- a/contracts/vault/offchainAsset/OffchainAssetReceiptVault.sol
+++ b/contracts/vault/offchainAsset/OffchainAssetReceiptVault.sol
@@ -10,6 +10,9 @@ import {MathUpgradeable as Math} from "@openzeppelin/contracts-upgradeable/utils
 /// Thrown when the asset is NOT address zero.
 error NonZeroAsset();
 
+/// Thrown when the admin is address zero.
+error ZeroAdmin();
+
 /// Thrown when a certification reference a block number in the future that
 /// cannot possibly have been seen yet.
 /// @param account The certifier that attempted the certify.
@@ -285,6 +288,10 @@ contract OffchainAssetReceiptVault is ReceiptVault, AccessControl {
         // There is no asset, the asset is offchain.
         if (config_.receiptVaultConfig.vaultConfig.asset != address(0)) {
             revert NonZeroAsset();
+        }
+        // The config admin MUST be set.
+        if (config_.admin == address(0)) {
+            revert ZeroAdmin();
         }
 
         // Define all admin roles. Note that admins can admin each other which

--- a/contracts/vault/receipt/IReceiptV1.sol
+++ b/contracts/vault/receipt/IReceiptV1.sol
@@ -34,7 +34,8 @@ interface IReceiptV1 is IERC1155 {
     /// `Ownable.owner` function signature as it is a very common and popular
     /// implementation. `IReceiptV1` has no opinion on how ownership is
     /// implemented and managed, it only cares that there is some owner.
-    function owner() external view returns (address owner);
+    /// @return account The owner account.
+    function owner() external view returns (address account);
 
     /// The owner MAY directly mint receipts for any account, ID and amount
     /// without restriction. The data MUST be treated as both ERC1155 data and

--- a/contracts/vault/receipt/IReceiptV1.sol
+++ b/contracts/vault/receipt/IReceiptV1.sol
@@ -58,7 +58,13 @@ interface IReceiptV1 is IERC1155 {
     /// @param account The account to burn a receipt for.
     /// @param id The receipt ID to burn.
     /// @param amount The amount to mint for the `id`.
-    function ownerBurn(address account, uint256 id, uint256 amount) external;
+    /// @param data MUST be emitted as receipt information.
+    function ownerBurn(
+        address account,
+        uint256 id,
+        uint256 amount,
+        bytes memory data
+    ) external;
 
     /// The owner MAY directly transfer receipts from and to any account for any
     /// id and amount without restriction. Overflow and underflow MUST revert as

--- a/contracts/vault/receipt/Receipt.sol
+++ b/contracts/vault/receipt/Receipt.sol
@@ -54,8 +54,10 @@ contract Receipt is IReceiptV1, Ownable, ERC1155 {
     function ownerBurn(
         address account_,
         uint256 id_,
-        uint256 amount_
+        uint256 amount_,
+        bytes memory data_
     ) external virtual onlyOwner {
+        _receiptInformation(account_, id_, data_);
         _burn(account_, id_, amount_);
     }
 

--- a/contracts/vault/receipt/Receipt.sol
+++ b/contracts/vault/receipt/Receipt.sol
@@ -46,8 +46,8 @@ contract Receipt is IReceiptV1, Ownable, ERC1155 {
         uint256 amount_,
         bytes memory data_
     ) external virtual onlyOwner {
-        _mint(account_, id_, amount_, data_);
         _receiptInformation(account_, id_, data_);
+        _mint(account_, id_, amount_, data_);
     }
 
     /// @inheritdoc IReceiptV1

--- a/contracts/vault/receipt/ReceiptVault.sol
+++ b/contracts/vault/receipt/ReceiptVault.sol
@@ -764,7 +764,14 @@ contract ReceiptVault is
             assets_,
             _shareRatio(owner_, receiver_, id_, ShareAction.Burn)
         );
-        _withdraw(assets_, receiver_, owner_, shares_, id_, receiptInformation_);
+        _withdraw(
+            assets_,
+            receiver_,
+            owner_,
+            shares_,
+            id_,
+            receiptInformation_
+        );
         return shares_;
     }
 
@@ -922,7 +929,14 @@ contract ReceiptVault is
             shares_,
             _shareRatio(owner_, receiver_, id_, ShareAction.Burn)
         );
-        _withdraw(assets_, receiver_, owner_, shares_, id_, receiptInformation_);
+        _withdraw(
+            assets_,
+            receiver_,
+            owner_,
+            shares_,
+            id_,
+            receiptInformation_
+        );
         return assets_;
     }
 

--- a/contracts/vault/receipt/ReceiptVault.sol
+++ b/contracts/vault/receipt/ReceiptVault.sol
@@ -556,6 +556,7 @@ contract ReceiptVault is
     /// due to rounding in different contexts so caller MUST calculate
     /// according to the rounding specification.
     /// @param id_ ID of the 1155 receipt and MUST be provided on withdrawal.
+    /// @param receiptInformation_ As per `Receipt` receipt information.
     function _deposit(
         uint256 assets_,
         address receiver_,

--- a/contracts/vault/receipt/ReceiptVault.sol
+++ b/contracts/vault/receipt/ReceiptVault.sol
@@ -752,19 +752,19 @@ contract ReceiptVault is
     /// @param receiver_ As per IERC4626 `withdraw`.
     /// @param owner_ As per IERC4626 `withdraw`.
     /// @param id_ As per `_withdraw`.
-    /// @param data_ As per `_withdraw`.
+    /// @param receiptInformation_ As per `_withdraw`.
     function withdraw(
         uint256 assets_,
         address receiver_,
         address owner_,
         uint256 id_,
-        bytes memory data_
+        bytes memory receiptInformation_
     ) public returns (uint256) {
         uint256 shares_ = _calculateWithdraw(
             assets_,
             _shareRatio(owner_, receiver_, id_, ShareAction.Burn)
         );
-        _withdraw(assets_, receiver_, owner_, shares_, id_, data_);
+        _withdraw(assets_, receiver_, owner_, shares_, id_, receiptInformation_);
         return shares_;
     }
 
@@ -910,19 +910,19 @@ contract ReceiptVault is
     /// @param owner_ As per IERC4626 `redeem`.
     /// @param id_ The reference id to redeem against. The owner MUST hold
     /// a receipt with id_ and it will be used to calculate the share ratio.
-    /// @param data_ Associated data for the redemption.
+    /// @param receiptInformation_ Associated receipt data for the redemption.
     function redeem(
         uint256 shares_,
         address receiver_,
         address owner_,
         uint256 id_,
-        bytes memory data_
+        bytes memory receiptInformation_
     ) public returns (uint256) {
         uint256 assets_ = _calculateRedeem(
             shares_,
             _shareRatio(owner_, receiver_, id_, ShareAction.Burn)
         );
-        _withdraw(assets_, receiver_, owner_, shares_, id_, data_);
+        _withdraw(assets_, receiver_, owner_, shares_, id_, receiptInformation_);
         return assets_;
     }
 

--- a/scripts/deploy/deploy.ts
+++ b/scripts/deploy/deploy.ts
@@ -1,12 +1,11 @@
 // scripts/deploy.js
 // @ts-ignore
 import { ethers, artifacts } from "hardhat";
-import type { ChainlinkFeedPriceOracleFactory } from "../../typechain";
-import type { ChainlinkFeedPriceOracle } from "../../typechain";
-import type { TwoPriceOracle } from "../../typechain";
-import type { TwoPriceOracleFactory } from "../../typechain";
-import type { ERC20PriceOracleReceiptVaultFactory } from "../../typechain";
-import type { ERC20PriceOracleReceiptVault } from "../../typechain";
+import type { ChainlinkFeedPriceOracleFactory } from "../../typechain-types";
+import type { ChainlinkFeedPriceOracle } from "../../typechain-types";
+import type { TwoPriceOracleFactory } from "../../typechain-types";
+import type { ERC20PriceOracleReceiptVaultFactory } from "../../typechain-types";
+import type { ERC20PriceOracleReceiptVault } from "../../typechain-types";
 
 import type { Contract } from "ethers";
 import { getEventArgs } from "../../test/util";

--- a/scripts/deploy/deployOffChainAssetReceiptVaultFactory.ts
+++ b/scripts/deploy/deployOffChainAssetReceiptVaultFactory.ts
@@ -5,10 +5,10 @@ import { artifacts, ethers } from "hardhat";
 import {
   OffchainAssetReceiptVaultFactory,
   ReceiptFactory,
-} from "../../typechain";
+} from "../../typechain-types";
 
 async function main() {
-  await deployOffChainReceiptAssetVaultFactory("Mumbai");
+  await deployOffChainAssetReceiptVaultFactory("Mumbai");
 }
 
 main()

--- a/test/offchainAsset/OffChainAssetReceiptVault.test.ts
+++ b/test/offchainAsset/OffChainAssetReceiptVault.test.ts
@@ -104,7 +104,7 @@ describe("OffChainAssetReceiptVault", async function () {
     const { sender, tier, minimumTier } = (await getEventArgs(
       await vault
         .connect(alice)
-        .setERC20Tier(TierV2TestContract.address, minTier, []),
+        .setERC20Tier(TierV2TestContract.address, minTier, [], []),
       "SetERC20Tier",
       vault
     )) as SetERC20TierEvent["args"];
@@ -136,7 +136,7 @@ describe("OffChainAssetReceiptVault", async function () {
     const { sender, tier, minimumTier } = (await getEventArgs(
       await vault
         .connect(alice)
-        .setERC1155Tier(TierV2TestContract.address, minTier, []),
+        .setERC1155Tier(TierV2TestContract.address, minTier, [],[]),
       "SetERC1155Tier",
       vault
     )) as SetERC1155TierEvent["args"];
@@ -525,7 +525,7 @@ describe("OffChainAssetReceiptVault", async function () {
       .grantRole(await vault.connect(alice).ERC20SNAPSHOTTER(), alice.address);
 
     const { id } = (await getEventArgs(
-      await vault.connect(alice).snapshot(),
+      await vault.connect(alice).snapshot([]),
       "Snapshot",
       vault
     )) as SnapshotEvent["args"];
@@ -546,14 +546,14 @@ describe("OffChainAssetReceiptVault", async function () {
     const { tier, minimumTier } = (await getEventArgs(
       await vault
         .connect(alice)
-        .setERC20Tier(TierV2TestContract.address, minTier, []),
+        .setERC20Tier(TierV2TestContract.address, minTier, [],[]),
       "SetERC20Tier",
       vault
     )) as SetERC20TierEvent["args"];
 
     await vault
       .connect(alice)
-      .setERC20Tier(TierV2TestContract.address, minTier, []);
+      .setERC20Tier(TierV2TestContract.address, minTier, [],[]);
 
     assert(
       tier === TierV2TestContract.address,
@@ -578,14 +578,14 @@ describe("OffChainAssetReceiptVault", async function () {
     const { tier, minimumTier } = (await getEventArgs(
       await vault
         .connect(alice)
-        .setERC1155Tier(TierV2TestContract.address, minTier, []),
+        .setERC1155Tier(TierV2TestContract.address, minTier, [],[]),
       "SetERC1155Tier",
       vault
     )) as SetERC20TierEvent["args"];
 
     await vault
       .connect(alice)
-      .setERC1155Tier(TierV2TestContract.address, minTier, []);
+      .setERC1155Tier(TierV2TestContract.address, minTier, [],[]);
 
     assert(
       tier === TierV2TestContract.address,
@@ -803,7 +803,7 @@ describe("OffChainAssetReceiptVault", async function () {
     const [vault] = await deployOffChainAssetReceiptVault();
 
     await assertError(
-      async () => await vault.connect(alice).confiscateShares(alice.address),
+      async () => await vault.connect(alice).confiscateShares(alice.address,[]),
       `AccessControl: account ${alice.address.toLowerCase()} is missing role ${await vault
         .connect(alice)
         .CONFISCATOR()}`,
@@ -820,7 +820,7 @@ describe("OffChainAssetReceiptVault", async function () {
       .grantRole(await vault.connect(alice).CONFISCATOR(), alice.address);
 
     const { sender, confiscatee } = (await getEventArgs(
-      await vault.connect(alice).confiscateShares(alice.address),
+      await vault.connect(alice).confiscateShares(alice.address,[]),
       "ConfiscateShares",
       vault
     )) as ConfiscateSharesEvent["args"];
@@ -846,7 +846,7 @@ describe("OffChainAssetReceiptVault", async function () {
       .grantRole(await vault.connect(alice).CONFISCATOR(), alice.address);
 
     const { sender, confiscatee, id } = (await getEventArgs(
-      await vault.connect(alice).confiscateReceipt(alice.address, _id),
+      await vault.connect(alice).confiscateReceipt(alice.address, _id,[]),
       "ConfiscateReceipt",
       vault
     )) as ConfiscateReceiptEvent["args"];
@@ -899,7 +899,7 @@ describe("OffChainAssetReceiptVault", async function () {
       ["balanceOf(address)"](alice.address);
 
     const { confiscated } = (await getEventArgs(
-      await vault.connect(alice).confiscateShares(alice.address),
+      await vault.connect(alice).confiscateShares(alice.address,[]),
       "ConfiscateShares",
       vault
     )) as ConfiscateSharesEvent["args"];
@@ -942,7 +942,7 @@ describe("OffChainAssetReceiptVault", async function () {
       ["balanceOf(address)"](alice.address);
 
     const { confiscated } = (await getEventArgs(
-      await vault.connect(alice).confiscateShares(bob.address),
+      await vault.connect(alice).confiscateShares(bob.address,[]),
       "ConfiscateShares",
       vault
     )) as ConfiscateSharesEvent["args"];
@@ -1010,7 +1010,7 @@ describe("OffChainAssetReceiptVault", async function () {
     const erc20balanceBef = await vault.connect(alice).balanceOf(bob.address);
 
     const { confiscated } = (await getEventArgs(
-      await vault.connect(alice).confiscateReceipt(bob.address, id),
+      await vault.connect(alice).confiscateReceipt(bob.address, id,[]),
       "ConfiscateReceipt",
       vault
     )) as ConfiscateSharesEvent["args"];
@@ -1080,7 +1080,7 @@ describe("OffChainAssetReceiptVault", async function () {
       ["balanceOf(address,uint256)"](alice.address, id);
 
     const { confiscated } = (await getEventArgs(
-      await vault.connect(alice).confiscateReceipt(bob.address, id),
+      await vault.connect(alice).confiscateReceipt(bob.address, id,[]),
       "ConfiscateReceipt",
       vault
     )) as ConfiscateSharesEvent["args"];
@@ -1304,7 +1304,7 @@ describe("OffChainAssetReceiptVault", async function () {
 
     await vault
       .connect(alice)
-      .setERC1155Tier(TierV2TestContract.address, minTier, []);
+      .setERC1155Tier(TierV2TestContract.address, minTier, [],[]);
 
     await assertError(
       async () =>

--- a/test/offchainAsset/OffChainAssetReceiptVault.test.ts
+++ b/test/offchainAsset/OffChainAssetReceiptVault.test.ts
@@ -1184,7 +1184,7 @@ describe("OffChainAssetReceiptVault", async function () {
       ["mint(uint256,address,uint256,bytes)"](shares2, bob.address, 2, []);
 
     let ABI = [
-      "function redeem(uint256 shares_, address receiver_, address owner_, uint256 id_)",
+      "function redeem(uint256 shares_, address receiver_, address owner_, uint256 id_, bytes receiptInformation_)",
     ];
     let iface = new ethers.utils.Interface(ABI);
     await vault
@@ -1200,12 +1200,14 @@ describe("OffChainAssetReceiptVault", async function () {
             bob.address,
             bob.address,
             1,
+            [],
           ]),
           iface.encodeFunctionData("redeem", [
             ethers.BigNumber.from(20),
             bob.address,
             bob.address,
             2,
+            [],
           ]),
         ],
         { from: bob.address }

--- a/test/offchainAsset/OffChainAssetReceiptVault.test.ts
+++ b/test/offchainAsset/OffChainAssetReceiptVault.test.ts
@@ -1259,13 +1259,11 @@ describe("OffChainAssetReceiptVault", async function () {
     await assertError(
       async () =>
         await vault
-          .connect(alice)
-          ["redeem(uint256,address,address,uint256)"](
-            balance.add(1),
+          .connect(alice)["redeem(uint256,address,address,uint256,bytes)"](
+              balance.add(1),
             alice.address,
             alice.address,
-            id
-          ),
+            id,[]),
       "ERC20: burn amount exceeds balance",
       "failed to prevent withdraw on more than balance"
     );
@@ -1308,11 +1306,12 @@ describe("OffChainAssetReceiptVault", async function () {
       async () =>
         await vault
           .connect(bob)
-          ["redeem(uint256,address,address,uint256)"](
+          ["redeem(uint256,address,address,uint256,bytes)"](
             balance,
             alice.address,
             alice.address,
-            id
+            id,
+            []
           ),
       "ERC20: insufficient allowance",
       "failed to prevent withdraw on someone else's shares"

--- a/test/offchainAsset/OffChainAssetReceiptVault.test.ts
+++ b/test/offchainAsset/OffChainAssetReceiptVault.test.ts
@@ -859,6 +859,30 @@ describe("OffChainAssetReceiptVault", async function () {
       "failed to confiscate"
     );
   });
+  it.only("Confiscate - Checks ConfiscateShares is NOT emitted on Zero balance", async function () {
+    const signers = await ethers.getSigners();
+    const alice = signers[0];
+    const [vault] = await deployOffChainAssetReceiptVault();
+
+    await vault
+      .connect(alice)
+      .grantRole(await vault.connect(alice).CONFISCATOR(), alice.address);
+
+    try {
+      await getEventArgs(
+        await vault.connect(alice).confiscateShares(alice.address, [1]),
+        "ConfiscateShares",
+        vault
+      );
+    } catch (err) {
+      assert(
+        err
+          .toString()
+          .includes("Error: Could not find event with name ConfiscateShares"),
+        `ConfiscateShares was emitted`
+      );
+    }
+  });
   it("Confiscate - Checks ConfiscateShares is emitted", async function () {
     const signers = await ethers.getSigners();
     const alice = signers[0];
@@ -976,6 +1000,33 @@ describe("OffChainAssetReceiptVault", async function () {
       justification === "0x01",
       `wrong justification expected 0x01 got ${justification}`
     );
+  });
+  it.only("Confiscate receipts - Checks ConfiscateReceipt is NOT emitted on zero balance", async function () {
+    const signers = await ethers.getSigners();
+    const [vault] = await deployOffChainAssetReceiptVault();
+
+    const alice = signers[0];
+
+    const _id = ethers.BigNumber.from(1);
+
+    await vault
+      .connect(alice)
+      .grantRole(await vault.connect(alice).CONFISCATOR(), alice.address);
+
+    try {
+      await getEventArgs(
+        await vault.connect(alice).confiscateReceipt(alice.address, _id, [1]),
+        "ConfiscateReceipt",
+        vault
+      );
+    } catch (err) {
+      assert(
+        err
+          .toString()
+          .includes("Error: Could not find event with name ConfiscateReceipt"),
+        `ConfiscateReceipt was emitted`
+      );
+    }
   });
   it("Checks confiscated is same as balance", async function () {
     const signers = await ethers.getSigners();

--- a/test/offchainAsset/OffChainAssetReceiptVault.test.ts
+++ b/test/offchainAsset/OffChainAssetReceiptVault.test.ts
@@ -18,6 +18,7 @@ import {
   ConfiscateSharesEvent,
   ConfiscateReceiptEvent,
   SetERC1155TierEvent,
+  SnapshotWithDataEvent,
 } from "../../typechain-types/contracts/vault/offchainAsset/OffchainAssetReceiptVault";
 import {
   deployOffChainAssetReceiptVault,
@@ -553,6 +554,29 @@ describe("OffChainAssetReceiptVault", async function () {
     )) as SnapshotEvent["args"];
 
     assert(id.eq(ethers.BigNumber.from(1)), `ID not set`);
+  });
+  it("SnapshotWithData event is emitted", async function () {
+    const signers = await ethers.getSigners();
+    const alice = signers[0];
+    const [vault] = await deployOffChainAssetReceiptVault();
+
+    await vault
+      .connect(alice)
+      .grantRole(await vault.connect(alice).ERC20SNAPSHOTTER(), alice.address);
+
+    const { sender, id, data } = (await getEventArgs(
+      await vault.connect(alice).snapshot([1]),
+      "SnapshotWithData",
+      vault
+    )) as SnapshotWithDataEvent["args"];
+
+    assert(id.eq(ethers.BigNumber.from(1)), `ID not set`);
+
+    assert(
+      sender === alice.address,
+      `Wrong sender. Expected ${alice.address}, got ${sender}`
+    );
+    assert(data === "0x01", `Wrong information. Expected 0x01, got ${data}`);
   });
   it("Sets correct erc20Tier and mintier", async function () {
     const [vault] = await deployOffChainAssetReceiptVault();

--- a/test/offchainAsset/OffChainAssetReceiptVault.test.ts
+++ b/test/offchainAsset/OffChainAssetReceiptVault.test.ts
@@ -37,6 +37,28 @@ describe("OffChainAssetReceiptVault", async function () {
     TierV2TestContract = (await TierV2Test.deploy()) as ReadWriteTier;
     await TierV2TestContract.deployed();
   });
+  it("Check admin is not address zero", async function () {
+    const offchainAssetReceiptVaultFactory =
+      await deployOffchainAssetReceiptVaultFactory();
+
+    const constructionConfig = {
+      admin: ADDRESS_ZERO,
+      vaultConfig: {
+        asset: ADDRESS_ZERO,
+        name: "OffchainAssetVaul",
+        symbol: "OAV",
+      },
+    };
+
+    await assertError(
+      async () =>
+        await offchainAssetReceiptVaultFactory.createChildTyped(
+          constructionConfig
+        ),
+      `ZeroAdmin()`,
+      "Failed to initialize"
+    );
+  });
   it("Check asset is address zero", async function () {
     const signers = await ethers.getSigners();
     const alice = signers[0];

--- a/test/offchainAsset/OffChainAssetReceiptVault.test.ts
+++ b/test/offchainAsset/OffChainAssetReceiptVault.test.ts
@@ -86,7 +86,7 @@ describe("OffChainAssetReceiptVault", async function () {
     );
   });
   it("Constructs well", async function () {
-    const [vault, receipt, config] = await deployOffChainAssetReceiptVault();
+    const [, , config] = await deployOffChainAssetReceiptVault();
 
     assert(
       config.receiptVaultConfig.vaultConfig.name === expectedName,
@@ -124,10 +124,10 @@ describe("OffChainAssetReceiptVault", async function () {
       .grantRole(await vault.connect(alice).ERC20TIERER(), alice.address);
     const minTier = ethers.BigNumber.from(10);
 
-    const { sender, tier, minimumTier } = (await getEventArgs(
+    const { sender, tier, minimumTier, data } = (await getEventArgs(
       await vault
         .connect(alice)
-        .setERC20Tier(TierV2TestContract.address, minTier, [], []),
+        .setERC20Tier(TierV2TestContract.address, minTier, [], [1]),
       "SetERC20Tier",
       vault
     )) as SetERC20TierEvent["args"];
@@ -144,6 +144,7 @@ describe("OffChainAssetReceiptVault", async function () {
       minimumTier.eq(minTier),
       `wrong minimumTier expected ${minTier} got ${minimumTier}`
     );
+    assert(data === "0x01", `wrong data expected 0x01 got ${data}`);
   });
   it("Checks setERC1155Tier event is emitted", async function () {
     const [vault] = await deployOffChainAssetReceiptVault();
@@ -156,10 +157,10 @@ describe("OffChainAssetReceiptVault", async function () {
       .grantRole(await vault.connect(alice).ERC1155TIERER(), alice.address);
     const minTier = ethers.BigNumber.from(100);
 
-    const { sender, tier, minimumTier } = (await getEventArgs(
+    const { sender, tier, minimumTier, data } = (await getEventArgs(
       await vault
         .connect(alice)
-        .setERC1155Tier(TierV2TestContract.address, minTier, [], []),
+        .setERC1155Tier(TierV2TestContract.address, minTier, [], [1]),
       "SetERC1155Tier",
       vault
     )) as SetERC1155TierEvent["args"];
@@ -176,6 +177,7 @@ describe("OffChainAssetReceiptVault", async function () {
       minimumTier.eq(minTier),
       `wrong minimumTier expected ${minTier} got ${minimumTier}`
     );
+    assert(data === "0x01", `wrong data expected 0x01 got ${data}`);
   });
   it("Checks totalAssets", async function () {
     const signers = await ethers.getSigners();
@@ -423,7 +425,7 @@ describe("OffChainAssetReceiptVault", async function () {
   it("Redeposit - should be receipt holder", async function () {
     const signers = await ethers.getSigners();
     const alice = signers[0];
-    const [vault, receipt] = await deployOffChainAssetReceiptVault();
+    const [, receipt] = await deployOffChainAssetReceiptVault();
 
     const aliceReceiptBalance = await receipt
       .connect(alice)
@@ -890,8 +892,8 @@ describe("OffChainAssetReceiptVault", async function () {
         []
       );
 
-    const { sender, confiscatee } = (await getEventArgs(
-      await vault.connect(alice).confiscateShares(alice.address, []),
+    const { sender, confiscatee, justification } = (await getEventArgs(
+      await vault.connect(alice).confiscateShares(alice.address, [1]),
       "ConfiscateShares",
       vault
     )) as ConfiscateSharesEvent["args"];
@@ -903,6 +905,10 @@ describe("OffChainAssetReceiptVault", async function () {
     assert(
       confiscatee === alice.address,
       `wrong confiscatee expected ${alice.address} got ${confiscatee}`
+    );
+    assert(
+      justification === "0x01",
+      `wrong justification expected 0x01 got ${justification}`
     );
   });
   it("Confiscate receipts - Checks ConfiscateReceipt is emitted", async function () {
@@ -950,8 +956,8 @@ describe("OffChainAssetReceiptVault", async function () {
         []
       );
 
-    const { sender, confiscatee, id } = (await getEventArgs(
-      await vault.connect(alice).confiscateReceipt(alice.address, _id, []),
+    const { sender, confiscatee, id, justification } = (await getEventArgs(
+      await vault.connect(alice).confiscateReceipt(alice.address, _id, [1]),
       "ConfiscateReceipt",
       vault
     )) as ConfiscateReceiptEvent["args"];
@@ -965,6 +971,11 @@ describe("OffChainAssetReceiptVault", async function () {
       `wrong confiscatee expected ${alice.address} got ${confiscatee}`
     );
     assert(id.eq(_id), `wrong id expected ${_id} got ${id}`);
+
+    assert(
+      justification === "0x01",
+      `wrong justification expected 0x01 got ${justification}`
+    );
   });
   it("Checks confiscated is same as balance", async function () {
     const signers = await ethers.getSigners();

--- a/test/offchainAsset/OffChainAssetReceiptVault.test.ts
+++ b/test/offchainAsset/OffChainAssetReceiptVault.test.ts
@@ -136,7 +136,7 @@ describe("OffChainAssetReceiptVault", async function () {
     const { sender, tier, minimumTier } = (await getEventArgs(
       await vault
         .connect(alice)
-        .setERC1155Tier(TierV2TestContract.address, minTier, [],[]),
+        .setERC1155Tier(TierV2TestContract.address, minTier, [], []),
       "SetERC1155Tier",
       vault
     )) as SetERC1155TierEvent["args"];
@@ -546,14 +546,14 @@ describe("OffChainAssetReceiptVault", async function () {
     const { tier, minimumTier } = (await getEventArgs(
       await vault
         .connect(alice)
-        .setERC20Tier(TierV2TestContract.address, minTier, [],[]),
+        .setERC20Tier(TierV2TestContract.address, minTier, [], []),
       "SetERC20Tier",
       vault
     )) as SetERC20TierEvent["args"];
 
     await vault
       .connect(alice)
-      .setERC20Tier(TierV2TestContract.address, minTier, [],[]);
+      .setERC20Tier(TierV2TestContract.address, minTier, [], []);
 
     assert(
       tier === TierV2TestContract.address,
@@ -578,14 +578,14 @@ describe("OffChainAssetReceiptVault", async function () {
     const { tier, minimumTier } = (await getEventArgs(
       await vault
         .connect(alice)
-        .setERC1155Tier(TierV2TestContract.address, minTier, [],[]),
+        .setERC1155Tier(TierV2TestContract.address, minTier, [], []),
       "SetERC1155Tier",
       vault
     )) as SetERC20TierEvent["args"];
 
     await vault
       .connect(alice)
-      .setERC1155Tier(TierV2TestContract.address, minTier, [],[]);
+      .setERC1155Tier(TierV2TestContract.address, minTier, [], []);
 
     assert(
       tier === TierV2TestContract.address,
@@ -803,7 +803,8 @@ describe("OffChainAssetReceiptVault", async function () {
     const [vault] = await deployOffChainAssetReceiptVault();
 
     await assertError(
-      async () => await vault.connect(alice).confiscateShares(alice.address,[]),
+      async () =>
+        await vault.connect(alice).confiscateShares(alice.address, []),
       `AccessControl: account ${alice.address.toLowerCase()} is missing role ${await vault
         .connect(alice)
         .CONFISCATOR()}`,
@@ -820,31 +821,31 @@ describe("OffChainAssetReceiptVault", async function () {
     await asset.deployed();
 
     await vault
-        .connect(alice)
-        .grantRole(await vault.connect(alice).CONFISCATOR(), alice.address);
+      .connect(alice)
+      .grantRole(await vault.connect(alice).CONFISCATOR(), alice.address);
     await vault
-        .connect(alice)
-        .grantRole(await vault.connect(alice).DEPOSITOR(), alice.address);
+      .connect(alice)
+      .grantRole(await vault.connect(alice).DEPOSITOR(), alice.address);
 
     const assets = ethers.BigNumber.from(100);
 
     await asset.transfer(alice.address, assets);
 
     await asset
-        .connect(alice)
-        .increaseAllowance(vault.connect(alice).address, assets);
+      .connect(alice)
+      .increaseAllowance(vault.connect(alice).address, assets);
 
     await vault
-        .connect(alice)
-        ["deposit(uint256,address,uint256,bytes)"](
+      .connect(alice)
+      ["deposit(uint256,address,uint256,bytes)"](
         assets,
         alice.address,
         ONE,
         []
-    );
+      );
 
     const { sender, confiscatee } = (await getEventArgs(
-      await vault.connect(alice).confiscateShares(alice.address,[]),
+      await vault.connect(alice).confiscateShares(alice.address, []),
       "ConfiscateShares",
       vault
     )) as ConfiscateSharesEvent["args"];
@@ -877,34 +878,34 @@ describe("OffChainAssetReceiptVault", async function () {
     const _certifiedUntil = block.timestamp + 100;
     const _referenceBlockNumber = block.number;
     await vault
-        .connect(alice)
-        .grantRole(await vault.connect(alice).CERTIFIER(), alice.address);
+      .connect(alice)
+      .grantRole(await vault.connect(alice).CERTIFIER(), alice.address);
     await vault
-        .connect(alice)
-        .certify(_certifiedUntil, _referenceBlockNumber, false, []);
+      .connect(alice)
+      .certify(_certifiedUntil, _referenceBlockNumber, false, []);
 
     await asset.transfer(alice.address, aliceAssets);
 
     await asset.connect(alice).increaseAllowance(vault.address, aliceAssets);
 
     await vault
-        .connect(alice)
-        .grantRole(await vault.connect(alice).DEPOSITOR(), alice.address);
+      .connect(alice)
+      .grantRole(await vault.connect(alice).DEPOSITOR(), alice.address);
     await vault
-        .connect(alice)
-        .grantRole(await vault.connect(alice).CONFISCATOR(), alice.address);
+      .connect(alice)
+      .grantRole(await vault.connect(alice).CONFISCATOR(), alice.address);
 
-
-        await vault
-            .connect(alice)
-            ["deposit(uint256,address,uint256,bytes)"](
-            aliceAssets,
-            alice.address,
-            _id,
-            [])
+    await vault
+      .connect(alice)
+      ["deposit(uint256,address,uint256,bytes)"](
+        aliceAssets,
+        alice.address,
+        _id,
+        []
+      );
 
     const { sender, confiscatee, id } = (await getEventArgs(
-      await vault.connect(alice).confiscateReceipt(alice.address, _id,[]),
+      await vault.connect(alice).confiscateReceipt(alice.address, _id, []),
       "ConfiscateReceipt",
       vault
     )) as ConfiscateReceiptEvent["args"];
@@ -957,7 +958,7 @@ describe("OffChainAssetReceiptVault", async function () {
       ["balanceOf(address)"](alice.address);
 
     const { confiscated } = (await getEventArgs(
-      await vault.connect(alice).confiscateShares(alice.address,[]),
+      await vault.connect(alice).confiscateShares(alice.address, []),
       "ConfiscateShares",
       vault
     )) as ConfiscateSharesEvent["args"];
@@ -1000,7 +1001,7 @@ describe("OffChainAssetReceiptVault", async function () {
       ["balanceOf(address)"](alice.address);
 
     const { confiscated } = (await getEventArgs(
-      await vault.connect(alice).confiscateShares(bob.address,[]),
+      await vault.connect(alice).confiscateShares(bob.address, []),
       "ConfiscateShares",
       vault
     )) as ConfiscateSharesEvent["args"];
@@ -1068,7 +1069,7 @@ describe("OffChainAssetReceiptVault", async function () {
     const erc20balanceBef = await vault.connect(alice).balanceOf(bob.address);
 
     const { confiscated } = (await getEventArgs(
-      await vault.connect(alice).confiscateReceipt(bob.address, id,[]),
+      await vault.connect(alice).confiscateReceipt(bob.address, id, []),
       "ConfiscateReceipt",
       vault
     )) as ConfiscateSharesEvent["args"];
@@ -1138,7 +1139,7 @@ describe("OffChainAssetReceiptVault", async function () {
       ["balanceOf(address,uint256)"](alice.address, id);
 
     const { confiscated } = (await getEventArgs(
-      await vault.connect(alice).confiscateReceipt(bob.address, id,[]),
+      await vault.connect(alice).confiscateReceipt(bob.address, id, []),
       "ConfiscateReceipt",
       vault
     )) as ConfiscateSharesEvent["args"];
@@ -1259,11 +1260,14 @@ describe("OffChainAssetReceiptVault", async function () {
     await assertError(
       async () =>
         await vault
-          .connect(alice)["redeem(uint256,address,address,uint256,bytes)"](
-              balance.add(1),
+          .connect(alice)
+          ["redeem(uint256,address,address,uint256,bytes)"](
+            balance.add(1),
             alice.address,
             alice.address,
-            id,[]),
+            id,
+            []
+          ),
       "ERC20: burn amount exceeds balance",
       "failed to prevent withdraw on more than balance"
     );
@@ -1361,7 +1365,7 @@ describe("OffChainAssetReceiptVault", async function () {
 
     await vault
       .connect(alice)
-      .setERC1155Tier(TierV2TestContract.address, minTier, [],[]);
+      .setERC1155Tier(TierV2TestContract.address, minTier, [], []);
 
     await assertError(
       async () =>

--- a/test/offchainAsset/Roles.test.ts
+++ b/test/offchainAsset/Roles.test.ts
@@ -157,11 +157,12 @@ describe("OffChainAssetReceiptVault Roles", async function () {
       .grantRole(await vault.connect(alice).WITHDRAWER(), bob.address);
     await vault
       .connect(bob)
-      ["redeem(uint256,address,address,uint256)"](
+      ["redeem(uint256,address,address,uint256,bytes)"](
         balance,
         bob.address,
         bob.address,
-        shareRatio
+        shareRatio,
+        []
       );
 
     const balanceAfter = await receipt
@@ -189,7 +190,7 @@ describe("OffChainAssetReceiptVault Roles", async function () {
       async () =>
         await vault
           .connect(alice)
-          .setERC20Tier(TierV2TestContract.address, minTier, []),
+          .setERC20Tier(TierV2TestContract.address, minTier, [], []),
       `AccessControl: account ${alice.address.toLowerCase()} is missing role ${await vault
         .connect(alice)
         .ERC20TIERER()}`,
@@ -211,7 +212,7 @@ describe("OffChainAssetReceiptVault Roles", async function () {
       async () =>
         await vault
           .connect(alice)
-          .setERC1155Tier(TierV2TestContract.address, minTier, []),
+          .setERC1155Tier(TierV2TestContract.address, minTier, [], []),
       `AccessControl: account ${alice.address.toLowerCase()} is missing role ${await vault
         .connect(alice)
         .ERC1155TIERER()}`,
@@ -224,7 +225,7 @@ describe("OffChainAssetReceiptVault Roles", async function () {
     const [vault] = await deployOffChainAssetReceiptVault();
 
     await assertError(
-      async () => await vault.connect(alice).snapshot(),
+      async () => await vault.connect(alice).snapshot([]),
       `AccessControl: account ${alice.address.toLowerCase()} is missing role ${await vault
         .connect(alice)
         .ERC20SNAPSHOTTER()}`,

--- a/test/priceOracle/Deposit.test.ts
+++ b/test/priceOracle/Deposit.test.ts
@@ -195,11 +195,12 @@ describe("deposit", async function () {
 
     await vault
       .connect(alice)
-      ["redeem(uint256,address,address,uint256)"](
+      ["redeem(uint256,address,address,uint256,bytes)"](
         erc1155Balance,
         alice.address,
         alice.address,
-        shareRatio
+        shareRatio,
+        []
       );
     const erc20AliceBalanceWithdraw = await vault
       .connect(alice)
@@ -215,11 +216,12 @@ describe("deposit", async function () {
       async () =>
         await vault
           .connect(alice)
-          ["redeem(uint256,address,address,uint256)"](
+          ["redeem(uint256,address,address,uint256,bytes)"](
             erc1155Balance.sub(1),
             alice.address,
             alice.address,
-            shareRatio
+            shareRatio,
+            []
           ),
       "burn amount exceeds balance",
       "failed to prevent shareRatio manipulation"
@@ -291,11 +293,12 @@ describe("deposit", async function () {
     // alice cannot withdraw after sending to bob.
     await assertError(
       async () =>
-        await aliceVault["redeem(uint256,address,address,uint256)"](
+        await aliceVault["redeem(uint256,address,address,uint256,bytes)"](
           1000,
           alice.address,
           alice.address,
-          shareRatio
+          shareRatio,
+          []
         ),
       "burn amount exceeds balance",
       "failed to prevent alice withdrawing after sending erc1155"
@@ -304,11 +307,12 @@ describe("deposit", async function () {
     // bob cannot withdraw without erc20
     await assertError(
       async () =>
-        await bobVault["redeem(uint256,address,address,uint256)"](
+        await bobVault["redeem(uint256,address,address,uint256,bytes)"](
           1000,
           bob.address,
           bob.address,
-          shareRatio
+          shareRatio,
+          []
         ),
       "burn amount exceeds balance",
       "failed to prevent bob withdrawing without receiving erc20"
@@ -319,11 +323,12 @@ describe("deposit", async function () {
 
     await assertError(
       async () =>
-        await aliceVault["redeem(uint256,address,address,uint256)"](
+        await aliceVault["redeem(uint256,address,address,uint256,bytes)"](
           1000,
           alice.address,
           alice.address,
-          shareRatio
+          shareRatio,
+          []
         ),
       "burn amount exceeds balance",
       "failed to prevent alice withdrawing after sending erc1155 and erc20"
@@ -336,8 +341,8 @@ describe("deposit", async function () {
       ["balanceOf(address,uint256)"](bob.address, id1155);
 
     const bobRedeemTx = await bobVault[
-      "redeem(uint256,address,address,uint256)"
-    ](bobReceiptBalance, bob.address, bob.address, shareRatio);
+      "redeem(uint256,address,address,uint256,bytes)"
+    ](bobReceiptBalance, bob.address, bob.address, shareRatio, []);
     await bobRedeemTx.wait();
     const bobReceiptBalanceAfter = await receipt
       .connect(alice)

--- a/test/priceOracle/Event.test.ts
+++ b/test/priceOracle/Event.test.ts
@@ -83,11 +83,12 @@ describe("events", async function () {
     const ERC1155Amount = aliceBalance;
     const redeemTx = await vault
       .connect(alice)
-      ["redeem(uint256,address,address,uint256)"](
+      ["redeem(uint256,address,address,uint256,bytes)"](
         ERC1155Amount,
         alice.address,
         alice.address,
-        shareRatio
+        shareRatio,
+        []
       );
 
     const withdrawEventArgs = await getEventArgs(redeemTx, "Withdraw", vault);

--- a/test/priceOracle/RedeemOverloaded.test.ts
+++ b/test/priceOracle/RedeemOverloaded.test.ts
@@ -61,11 +61,12 @@ describe("Overloaded Redeem", async function () {
 
     await vault
       .connect(alice)
-      ["redeem(uint256,address,address,uint256)"](
+      ["redeem(uint256,address,address,uint256,bytes)"](
         receiptBalance,
         aliceAddress,
         aliceAddress,
-        shareRatio
+        shareRatio,
+        []
       );
 
     const receiptBalanceAfter = await receipt
@@ -83,11 +84,12 @@ describe("Overloaded Redeem", async function () {
 
     await vault
       .connect(alice)
-      ["redeem(uint256,address,address,uint256)"](
+      ["redeem(uint256,address,address,uint256,bytes)"](
         receiptBalance.div(2),
         aliceAddress,
         aliceAddress,
-        shareRatio
+        shareRatio,
+        []
       );
 
     const receiptBalanceAfter = await receipt
@@ -104,11 +106,12 @@ describe("Overloaded Redeem", async function () {
       async () =>
         await vault
           .connect(alice)
-          ["redeem(uint256,address,address,uint256)"](
+          ["redeem(uint256,address,address,uint256,bytes)"](
             ethers.BigNumber.from(0),
             aliceAddress,
             aliceAddress,
-            shareRatio
+            shareRatio,
+            []
           ),
       "ZeroAssetsAmount",
       "failed to prevent a zero assets redeem"
@@ -123,11 +126,12 @@ describe("Overloaded Redeem", async function () {
       async () =>
         await vault
           .connect(alice)
-          ["redeem(uint256,address,address,uint256)"](
+          ["redeem(uint256,address,address,uint256,bytes)"](
             receiptBalance,
             ADDRESS_ZERO,
             aliceAddress,
-            shareRatio
+            shareRatio,
+            []
           ),
       "ZeroReceiver",
       "failed to prevent a zero address receiver redeem"
@@ -142,11 +146,12 @@ describe("Overloaded Redeem", async function () {
       async () =>
         await vault
           .connect(alice)
-          ["redeem(uint256,address,address,uint256)"](
+          ["redeem(uint256,address,address,uint256,bytes)"](
             receiptBalance,
             aliceAddress,
             ADDRESS_ZERO,
-            shareRatio
+            shareRatio,
+            []
           ),
       "ZeroOwner",
       "failed to prevent a zero address owner redeem"
@@ -162,11 +167,12 @@ describe("Overloaded Redeem", async function () {
 
     const redeemTx = await vault
       .connect(alice)
-      ["redeem(uint256,address,address,uint256)"](
+      ["redeem(uint256,address,address,uint256,bytes)"](
         receiptBalance,
         aliceAddress,
         aliceAddress,
-        shareRatio
+        shareRatio,
+        []
       );
 
     const withdrawEvent = (await getEvent(

--- a/test/priceOracle/WithdrawOverloaded.test.ts
+++ b/test/priceOracle/WithdrawOverloaded.test.ts
@@ -65,11 +65,12 @@ describe("Overloaded Withdraw", async function () {
 
     await vault
       .connect(alice)
-      ["withdraw(uint256,address,address,uint256)"](
+      ["withdraw(uint256,address,address,uint256,bytes)"](
         withdrawBalance,
         aliceAddress,
         aliceAddress,
-        shareRatio
+        shareRatio,
+        []
       );
 
     const receiptBalanceAfter = await receipt
@@ -86,11 +87,12 @@ describe("Overloaded Withdraw", async function () {
       async () =>
         await vault
           .connect(alice)
-          ["withdraw(uint256,address,address,uint256)"](
+          ["withdraw(uint256,address,address,uint256,bytes)"](
             ethers.BigNumber.from(0),
             aliceAddress,
             aliceAddress,
-            shareRatio
+            shareRatio,
+            []
           ),
       "ZeroAssetsAmount",
       "failed to prevent a zero asset withdraw"
@@ -108,11 +110,12 @@ describe("Overloaded Withdraw", async function () {
       async () =>
         await vault
           .connect(alice)
-          ["withdraw(uint256,address,address,uint256)"](
+          ["withdraw(uint256,address,address,uint256,bytes)"](
             withdrawBalance,
             ADDRESS_ZERO,
             aliceAddress,
-            shareRatio
+            shareRatio,
+            []
           ),
       "ZeroReceiver",
       "failed to prevent a zero address receiver withdraw"
@@ -130,11 +133,12 @@ describe("Overloaded Withdraw", async function () {
       async () =>
         await vault
           .connect(alice)
-          ["withdraw(uint256,address,address,uint256)"](
+          ["withdraw(uint256,address,address,uint256,bytes)"](
             withdrawBalance,
             aliceAddress,
             ADDRESS_ZERO,
-            shareRatio
+            shareRatio,
+            []
           ),
       "ZeroOwner",
       "failed to prevent a zero address owner withdraw"
@@ -151,11 +155,12 @@ describe("Overloaded Withdraw", async function () {
     await vault.connect(alice).setWithdrawId(shareRatio);
     const withdrawTx = await vault
       .connect(alice)
-      ["withdraw(uint256,address,address,uint256)"](
+      ["withdraw(uint256,address,address,uint256,bytes)"](
         withdrawBalance,
         aliceAddress,
         aliceAddress,
-        shareRatio
+        shareRatio,
+        []
       );
 
     const withdrawEvent = (await getEvent(

--- a/test/receipt/Receipt.test.ts
+++ b/test/receipt/Receipt.test.ts
@@ -191,7 +191,7 @@ describe("Receipt vault", async function () {
       )}, got ${balanceAfter}`
     );
   });
-  it.only("Checks ReceiptInformation event is emitted with correct data", async function () {
+  it("Checks ReceiptInformation event is emitted with correct data", async function () {
     const signers = await ethers.getSigners();
     const alice = signers[0];
 
@@ -246,7 +246,6 @@ describe("Receipt vault", async function () {
     );
     assert(id.eq(receiptId), `Wrong id. Expected ${receiptId}, got ${id}`);
   });
-
   it("OwnerBurn fails while not enough balance to burn", async function () {
     const signers = await ethers.getSigners();
     const alice = signers[0];

--- a/test/receipt/Receipt.test.ts
+++ b/test/receipt/Receipt.test.ts
@@ -8,6 +8,7 @@ import {
   TestReceiptOwner,
 } from "../../typechain-types";
 import { Contract } from "ethers";
+import { ReceiptInformationEvent } from "../../typechain-types/contracts/vault/receipt/Receipt";
 
 const assert = require("assert");
 
@@ -190,6 +191,62 @@ describe("Receipt vault", async function () {
       )}, got ${balanceAfter}`
     );
   });
+  it.only("Checks ReceiptInformation event is emitted with correct data", async function () {
+    const signers = await ethers.getSigners();
+    const alice = signers[0];
+
+    const testErc20 = await ethers.getContractFactory("TestErc20");
+    const asset = (await testErc20.deploy()) as TestErc20;
+    await asset.deployed();
+
+    const testReceipt = await ethers.getContractFactory("TestReceipt");
+    const receipt = (await testReceipt.deploy()) as TestReceipt;
+    await receipt.deployed();
+
+    const testReceiptOwner = await ethers.getContractFactory(
+      "TestReceiptOwner"
+    );
+    const receiptOwner = (await testReceiptOwner.deploy()) as TestReceiptOwner;
+    await receiptOwner.deployed();
+
+    await receipt.setOwner(receiptOwner.address);
+
+    await receiptOwner.setFrom(ADDRESS_ZERO);
+    await receiptOwner.setTo(alice.address);
+
+    const assets = ethers.BigNumber.from(30);
+    await asset.transfer(alice.address, assets);
+    await asset.connect(alice).increaseAllowance(receiptOwner.address, assets);
+
+    const receiptId = ethers.BigNumber.from(1);
+    const toMint = ethers.BigNumber.from(10);
+    await receiptOwner
+      .connect(alice)
+      .ownerMint(receipt.address, alice.address, receiptId, toMint, []);
+
+    const toBurn = ethers.BigNumber.from(5);
+    await receiptOwner.setFrom(alice.address);
+    await receiptOwner.setTo(ADDRESS_ZERO);
+
+    const { sender, id, information } = (await getEventArgs(
+      await receiptOwner
+        .connect(alice)
+        .ownerBurn(receipt.address, alice.address, receiptId, toBurn, [1]),
+      "ReceiptInformation",
+      receipt
+    )) as ReceiptInformationEvent["args"];
+
+    assert(
+      sender === alice.address,
+      `Wrong sender. Expected ${alice.address}, got ${sender}`
+    );
+    assert(
+      information === "0x01",
+      `Wrong information. Expected 0x01, got ${information}`
+    );
+    assert(id.eq(receiptId), `Wrong id. Expected ${receiptId}, got ${id}`);
+  });
+
   it("OwnerBurn fails while not enough balance to burn", async function () {
     const signers = await ethers.getSigners();
     const alice = signers[0];

--- a/test/receipt/Receipt.test.ts
+++ b/test/receipt/Receipt.test.ts
@@ -179,7 +179,7 @@ describe("Receipt vault", async function () {
 
     await receiptOwner
       .connect(alice)
-      .ownerBurn(receipt.address, alice.address, receiptId, toBurn);
+      .ownerBurn(receipt.address, alice.address, receiptId, toBurn, []);
 
     const balanceAfter = await receipt.balanceOf(alice.address, receiptId);
 
@@ -234,7 +234,7 @@ describe("Receipt vault", async function () {
       async () =>
         await receiptOwner
           .connect(alice)
-          .ownerBurn(receipt.address, alice.address, receiptId, toBurn),
+          .ownerBurn(receipt.address, alice.address, receiptId, toBurn, []),
       "ERC1155: burn amount exceeds balance",
       "failed to prevent ownerBurn"
     );

--- a/test/receipt/ReceiptVault.test.ts
+++ b/test/receipt/ReceiptVault.test.ts
@@ -1071,11 +1071,12 @@ describe("Overloaded `deposit`", async () => {
     const { sender, receiver, owner, assets, shares, id } = (await getEventArgs(
       await vault
         .connect(alice)
-        ["withdraw(uint256,address,address,uint256)"](
+        ["withdraw(uint256,address,address,uint256,bytes)"](
           erc1155Balance,
           alice.address,
           alice.address,
-          shareRatio
+          shareRatio,
+          []
         ),
       "WithdrawWithReceipt",
       vault

--- a/test/receipt/ReceiptVault.test.ts
+++ b/test/receipt/ReceiptVault.test.ts
@@ -87,7 +87,7 @@ describe("Receipt vault", async function () {
     const signers = await ethers.getSigners();
     const alice = signers[0];
 
-    const [vault, asset, priceOracle] = await deployERC20PriceOracleVault();
+    const [vault, , priceOracle] = await deployERC20PriceOracleVault();
 
     const shareRatio = await priceOracle.price();
 
@@ -126,7 +126,7 @@ describe("Receipt vault", async function () {
   it("Calculates correct shares", async function () {
     [owner] = await ethers.getSigners();
 
-    const [vault, asset, priceOracle] = await deployERC20PriceOracleVault();
+    const [vault, , priceOracle] = await deployERC20PriceOracleVault();
 
     const shareRatio = await priceOracle.price();
 
@@ -192,7 +192,7 @@ describe("Receipt vault", async function () {
     const signers = await ethers.getSigners();
     const alice = signers[0];
 
-    const [vault, asset, priceOracle] = await deployERC20PriceOracleVault();
+    const [vault, , priceOracle] = await deployERC20PriceOracleVault();
 
     const assets = ethers.BigNumber.from("10").pow(20);
     const shareRatio = await priceOracle.price();
@@ -206,7 +206,7 @@ describe("Receipt vault", async function () {
     );
   });
   it("Sets correct shares by previewDeposit", async function () {
-    const [vault, asset, priceOracle] = await deployERC20PriceOracleVault();
+    const [vault, , priceOracle] = await deployERC20PriceOracleVault();
     const signers = await ethers.getSigners();
     const alice = signers[0];
 
@@ -248,7 +248,7 @@ describe("Deposit", async () => {
       "MinShareRatio",
       "failed to respect min price"
     );
-  }),
+  })
     it("Calculates shares correctly with min shareRatio set", async function () {
       const signers = await ethers.getSigners();
 
@@ -283,40 +283,40 @@ describe("Deposit", async () => {
         shares.eq(expectedShares),
         `Wrong alice shares ${expectedShares} ${shares}`
       );
-    }),
-    it("Calculates shares correctly with NO min shareRatio set", async function () {
-      const signers = await ethers.getSigners();
-
-      const [vault, asset, priceOracle] = await deployERC20PriceOracleVault();
-
-      const alice = signers[1];
-
-      const totalTokenSupply = await asset.totalSupply();
-
-      const assets = totalTokenSupply.div(2);
-
-      // give alice reserve to cover cost
-      await asset.transfer(alice.address, assets);
-
-      // Min shareRatio MUST be respected
-      const shareRatio = await priceOracle.price();
-
-      await asset.connect(alice).increaseAllowance(vault.address, assets);
-
-      const expectedShares = fixedPointMul(assets, shareRatio);
-
-      await vault
-        .connect(alice)
-        ["deposit(uint256,address)"](assets, alice.address);
-      const shares = await vault
-        .connect(alice)
-        ["balanceOf(address)"](alice.address);
-
-      assert(
-        shares.eq(expectedShares),
-        `Wrong alice ETHg ${expectedShares} ${shares}`
-      );
     });
+  it("Calculates shares correctly with NO min shareRatio set", async function () {
+    const signers = await ethers.getSigners();
+
+    const [vault, asset, priceOracle] = await deployERC20PriceOracleVault();
+
+    const alice = signers[1];
+
+    const totalTokenSupply = await asset.totalSupply();
+
+    const assets = totalTokenSupply.div(2);
+
+    // give alice reserve to cover cost
+    await asset.transfer(alice.address, assets);
+
+    // Min shareRatio MUST be respected
+    const shareRatio = await priceOracle.price();
+
+    await asset.connect(alice).increaseAllowance(vault.address, assets);
+
+    const expectedShares = fixedPointMul(assets, shareRatio);
+
+    await vault
+      .connect(alice)
+      ["deposit(uint256,address)"](assets, alice.address);
+    const shares = await vault
+      .connect(alice)
+      ["balanceOf(address)"](alice.address);
+
+    assert(
+      shares.eq(expectedShares),
+      `Wrong alice ETHg ${expectedShares} ${shares}`
+    );
+  });
   it("Reverts if not enough assets to be transferred", async function () {
     const signers = await ethers.getSigners();
 
@@ -577,7 +577,7 @@ describe("Overloaded `deposit`", async () => {
       "MinShareRatio",
       "failed to respect min shareRatio"
     );
-  }),
+  })
     it("Calculates shares correctly with min shareRatio set", async function () {
       const signers = await ethers.getSigners();
 
@@ -617,45 +617,45 @@ describe("Overloaded `deposit`", async () => {
         shares.eq(expectedShares),
         `wrong alice shares ${expectedShares} ${shares}`
       );
-    }),
-    it("Calculates shares correctly with NO min shareRatio set", async function () {
-      const signers = await ethers.getSigners();
-
-      const [vault, asset, priceOracle] = await deployERC20PriceOracleVault();
-
-      const alice = signers[1];
-
-      const totalTokenSupply = await asset.totalSupply();
-
-      const assets = totalTokenSupply.div(2);
-
-      // give alice reserve to cover cost
-      await asset.transfer(alice.address, assets);
-
-      // Min shareRatio price MUST be respected
-      const shareRatio = await priceOracle.price();
-
-      await asset.connect(alice).increaseAllowance(vault.address, assets);
-
-      const expectedShares = fixedPointMul(assets, shareRatio);
-
-      await vault
-        .connect(alice)
-        ["deposit(uint256,address,uint256,bytes)"](
-          assets,
-          alice.address,
-          shareRatio,
-          []
-        );
-      const shares = await vault
-        .connect(alice)
-        ["balanceOf(address)"](alice.address);
-
-      assert(
-        shares.eq(expectedShares),
-        `wrong alice ETHg ${expectedShares} ${shares}`
-      );
     });
+  it("Calculates shares correctly with NO min shareRatio set", async function () {
+    const signers = await ethers.getSigners();
+
+    const [vault, asset, priceOracle] = await deployERC20PriceOracleVault();
+
+    const alice = signers[1];
+
+    const totalTokenSupply = await asset.totalSupply();
+
+    const assets = totalTokenSupply.div(2);
+
+    // give alice reserve to cover cost
+    await asset.transfer(alice.address, assets);
+
+    // Min shareRatio price MUST be respected
+    const shareRatio = await priceOracle.price();
+
+    await asset.connect(alice).increaseAllowance(vault.address, assets);
+
+    const expectedShares = fixedPointMul(assets, shareRatio);
+
+    await vault
+      .connect(alice)
+      ["deposit(uint256,address,uint256,bytes)"](
+        assets,
+        alice.address,
+        shareRatio,
+        []
+      );
+    const shares = await vault
+      .connect(alice)
+      ["balanceOf(address)"](alice.address);
+
+    assert(
+      shares.eq(expectedShares),
+      `wrong alice ETHg ${expectedShares} ${shares}`
+    );
+  });
   it("Reverts if not enough assets to be transferred", async function () {
     const signers = await ethers.getSigners();
 
@@ -1068,19 +1068,20 @@ describe("Overloaded `deposit`", async () => {
       .connect(alice)
       ["balanceOf(address,uint256)"](alice.address, shareRatio);
 
-    const { sender, receiver, owner, assets, shares, id } = (await getEventArgs(
-      await vault
-        .connect(alice)
-        ["withdraw(uint256,address,address,uint256,bytes)"](
-          erc1155Balance,
-          alice.address,
-          alice.address,
-          shareRatio,
-          []
-        ),
-      "WithdrawWithReceipt",
-      vault
-    )) as WithdrawWithReceiptEvent["args"];
+    const { sender, receiver, owner, assets, shares, id, receiptInformation } =
+      (await getEventArgs(
+        await vault
+          .connect(alice)
+          ["withdraw(uint256,address,address,uint256,bytes)"](
+            erc1155Balance,
+            alice.address,
+            alice.address,
+            shareRatio,
+            [1]
+          ),
+        "WithdrawWithReceipt",
+        vault
+      )) as WithdrawWithReceiptEvent["args"];
 
     const expectedShares = fixedPointMul(assets, shareRatio).add(1);
 
@@ -1109,6 +1110,11 @@ describe("Overloaded `deposit`", async () => {
     );
 
     assert(id.eq(expectedId), `wrong id expected ${id} got ${expectedId}`);
+
+    assert(
+      receiptInformation === "0x01",
+      `wrong receiptInformation expected 0x01 got ${receiptInformation}`
+    );
   });
 });
 describe("Mint", async function () {
@@ -1130,7 +1136,7 @@ describe("Mint", async function () {
     );
   });
   it("Checks min share ratio is less than share ratio", async function () {
-    const [vault, asset, priceOracle] = await deployERC20PriceOracleVault();
+    const [vault, , priceOracle] = await deployERC20PriceOracleVault();
     const shareRatio = await priceOracle.price();
 
     const signers = await ethers.getSigners();
@@ -1147,7 +1153,7 @@ describe("Mint", async function () {
     );
   });
   it("PreviewMint - Calculates assets correctly with round up", async function () {
-    const [vault, asset, priceOracle] = await deployERC20PriceOracleVault();
+    const [vault, , priceOracle] = await deployERC20PriceOracleVault();
     const signers = await ethers.getSigners();
     const alice = signers[0];
     const shareRatio = await priceOracle.price();

--- a/test/receipt/ReceiptVault.test.ts
+++ b/test/receipt/ReceiptVault.test.ts
@@ -248,42 +248,42 @@ describe("Deposit", async () => {
       "MinShareRatio",
       "failed to respect min price"
     );
-  })
-    it("Calculates shares correctly with min shareRatio set", async function () {
-      const signers = await ethers.getSigners();
+  });
+  it("Calculates shares correctly with min shareRatio set", async function () {
+    const signers = await ethers.getSigners();
 
-      const [vault, asset, priceOracle] = await deployERC20PriceOracleVault();
+    const [vault, asset, priceOracle] = await deployERC20PriceOracleVault();
 
-      const alice = signers[1];
+    const alice = signers[1];
 
-      const totalTokenSupply = await asset.totalSupply();
+    const totalTokenSupply = await asset.totalSupply();
 
-      const assets = totalTokenSupply.div(2);
+    const assets = totalTokenSupply.div(2);
 
-      // give alice reserve to cover cost
-      await asset.transfer(alice.address, assets);
+    // give alice reserve to cover cost
+    await asset.transfer(alice.address, assets);
 
-      // Min shareRatio MUST be respected
-      const shareRatio = await priceOracle.price();
+    // Min shareRatio MUST be respected
+    const shareRatio = await priceOracle.price();
 
-      await asset.connect(alice).increaseAllowance(vault.address, assets);
+    await asset.connect(alice).increaseAllowance(vault.address, assets);
 
-      const expectedShares = fixedPointMul(assets, shareRatio);
+    const expectedShares = fixedPointMul(assets, shareRatio);
 
-      await vault.connect(alice).setMinShareRatio(shareRatio.sub(1));
+    await vault.connect(alice).setMinShareRatio(shareRatio.sub(1));
 
-      await vault
-        .connect(alice)
-        ["deposit(uint256,address)"](assets, alice.address);
-      const shares = await vault
-        .connect(alice)
-        ["balanceOf(address)"](alice.address);
+    await vault
+      .connect(alice)
+      ["deposit(uint256,address)"](assets, alice.address);
+    const shares = await vault
+      .connect(alice)
+      ["balanceOf(address)"](alice.address);
 
-      assert(
-        shares.eq(expectedShares),
-        `Wrong alice shares ${expectedShares} ${shares}`
-      );
-    });
+    assert(
+      shares.eq(expectedShares),
+      `Wrong alice shares ${expectedShares} ${shares}`
+    );
+  });
   it("Calculates shares correctly with NO min shareRatio set", async function () {
     const signers = await ethers.getSigners();
 
@@ -577,47 +577,47 @@ describe("Overloaded `deposit`", async () => {
       "MinShareRatio",
       "failed to respect min shareRatio"
     );
-  })
-    it("Calculates shares correctly with min shareRatio set", async function () {
-      const signers = await ethers.getSigners();
+  });
+  it("Calculates shares correctly with min shareRatio set", async function () {
+    const signers = await ethers.getSigners();
 
-      const [vault, asset, priceOracle] = await deployERC20PriceOracleVault();
+    const [vault, asset, priceOracle] = await deployERC20PriceOracleVault();
 
-      const alice = signers[1];
+    const alice = signers[1];
 
-      const totalTokenSupply = await asset.totalSupply();
+    const totalTokenSupply = await asset.totalSupply();
 
-      const assets = totalTokenSupply.div(2);
+    const assets = totalTokenSupply.div(2);
 
-      // give alice reserve to cover cost
-      await asset.transfer(alice.address, assets);
+    // give alice reserve to cover cost
+    await asset.transfer(alice.address, assets);
 
-      // Min shareRatio MUST be respected
-      const shareRatio = await priceOracle.price();
+    // Min shareRatio MUST be respected
+    const shareRatio = await priceOracle.price();
 
-      await asset.connect(alice).increaseAllowance(vault.address, assets);
+    await asset.connect(alice).increaseAllowance(vault.address, assets);
 
-      const expectedShares = fixedPointMul(assets, shareRatio);
+    const expectedShares = fixedPointMul(assets, shareRatio);
 
-      await vault.connect(alice).setMinShareRatio(shareRatio.sub(1));
+    await vault.connect(alice).setMinShareRatio(shareRatio.sub(1));
 
-      await vault
-        .connect(alice)
-        ["deposit(uint256,address,uint256,bytes)"](
-          assets,
-          alice.address,
-          shareRatio,
-          []
-        );
-      const shares = await vault
-        .connect(alice)
-        ["balanceOf(address)"](alice.address);
-
-      assert(
-        shares.eq(expectedShares),
-        `wrong alice shares ${expectedShares} ${shares}`
+    await vault
+      .connect(alice)
+      ["deposit(uint256,address,uint256,bytes)"](
+        assets,
+        alice.address,
+        shareRatio,
+        []
       );
-    });
+    const shares = await vault
+      .connect(alice)
+      ["balanceOf(address)"](alice.address);
+
+    assert(
+      shares.eq(expectedShares),
+      `wrong alice shares ${expectedShares} ${shares}`
+    );
+  });
   it("Calculates shares correctly with NO min shareRatio set", async function () {
     const signers = await ethers.getSigners();
 


### PR DESCRIPTION
- added an error if the admin is address 0 for OA
- only emit confiscate receipt event if nonzero confiscation actually happens
- add arbitrary bytes data for confiscate event
- bytes of data for snaphost event
- bytes of data for set erc20 and erc1155 tier
- bytes of data for withdraw/redeem - specifically receiptInformation with the receipt information event