### PR TITLE
96 test that redepositing works after there are several ids due to deposit and reverts past the top id not just for id 1

### DIFF
--- a/test/foundry/src/concrete/vault/OffchainAssetReceiptVault.redeposit.t.sol
+++ b/test/foundry/src/concrete/vault/OffchainAssetReceiptVault.redeposit.t.sol
@@ -84,11 +84,7 @@ contract RedepositTest is OffchainAssetReceiptVaultTest {
 
         vault.deposit(assets, bob, minShareRatio, data);
 
-        vm.expectEmit(false, false, false, true);
-        emit DepositWithReceipt(bob, bob, assetsToRedeposit, assetsToRedeposit, 1, data);
-
-        // Redeposit
-        vault.redeposit(assetsToRedeposit, bob, 1, data);
+        checkBalanceChange(vault, bob, bob, 1, assetsToRedeposit, data);
 
         vm.stopPrank();
     }
@@ -235,12 +231,7 @@ contract RedepositTest is OffchainAssetReceiptVaultTest {
         emit DepositWithReceipt(bob, alice, assets, assets, 1, data);
         vault.deposit(assets, alice, minShareRatio, data);
 
-        // Set up the event expectation for DepositWithReceipt
-        vm.expectEmit(false, false, false, true);
-        emit DepositWithReceipt(bob, alice, assets, assets, 1, data);
-
-        // Attempt to deposit, should revert
-        vault.redeposit(assets, alice, 1, data);
+        checkBalanceChange(vault, alice, bob, 1, assets, data);
 
         vm.stopPrank();
     }
@@ -286,11 +277,7 @@ contract RedepositTest is OffchainAssetReceiptVaultTest {
 
         vault.deposit(assets, alice, minShareRatio, data);
 
-        vm.expectEmit(false, false, false, true);
-        emit DepositWithReceipt(bob, alice, assetsToRedeposit, assetsToRedeposit, 1, data);
-
-        // Redeposit
-        vault.redeposit(assetsToRedeposit, alice, 1, data);
+        checkBalanceChange(vault, alice, bob, 1, assets, data);
 
         vm.stopPrank();
     }


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
Test redepositing works after there are several IDs due to deposit and reverts on invalid Id over max id

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add several tests for redeposit function in foundry
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
