### PR TITLE
Update testMintSomeoneElse to check receipt balances

### DIFF
--- a/test/src/concrete/vault/ERC20PriceOracleReceiptVault.mint.t.sol
+++ b/test/src/concrete/vault/ERC20PriceOracleReceiptVault.mint.t.sol
@@ -14,6 +14,7 @@ import {IERC20} from "forge-std/interfaces/IERC20.sol";
 import {LibUniqueAddressesGenerator} from "../../../lib/LibUniqueAddressesGenerator.sol";
 import {SFLR_CONTRACT} from "rain.flare/lib/sflr/LibSceptreStakedFlare.sol";
 import {LibERC20PriceOracleReceiptVaultFork} from "../../../lib/LibERC20PriceOracleReceiptVaultFork.sol";
+import {Receipt as ReceiptContract} from "src/concrete/receipt/Receipt.sol";
 
 contract ERC20PriceOracleReceiptVaultDepositTest is ERC20PriceOracleReceiptVaultTest {
     using LibFixedPointDecimalArithmeticOpenZeppelin for uint256;
@@ -69,7 +70,7 @@ contract ERC20PriceOracleReceiptVaultDepositTest is ERC20PriceOracleReceiptVault
 
         oraclePrice = bound(oraclePrice, 0.01e18, 100e18);
         setVaultOraclePrice(oraclePrice);
-
+        vm.recordLogs();
         ERC20PriceOracleReceiptVault vault = createVault(iVaultOracle, assetName, assetName);
 
         {
@@ -85,12 +86,21 @@ contract ERC20PriceOracleReceiptVaultDepositTest is ERC20PriceOracleReceiptVault
                 abi.encode(true)
             );
         }
+        ReceiptContract receipt = getReceipt();
+
+        uint256 aliceReceiptBalance = receipt.balanceOf(alice, oraclePrice);
         uint256 shares = assets.fixedPointMul(oraclePrice, Math.Rounding.Down);
 
         vault.mint(shares, bob, oraclePrice, bytes(""));
 
         // Check balance
         assertEqUint(vault.balanceOf(bob), shares);
+
+        // Check bob's receipt balance
+        assertEqUint(receipt.balanceOf(bob, oraclePrice), shares);
+
+        // Check alice's receipt balance does not change
+        assertEqUint(receipt.balanceOf(alice, oraclePrice), aliceReceiptBalance);
     }
 
     /// Test mint function with zero shares


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
mint tests for oracle vaults does not check erc1155 amounts, only erc20 amounts
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add erc1155 amount checks

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
