### PR TITLE
177 test for oracle vault for multiple prices and historical redemptions

### DIFF
--- a/test/src/concrete/vault/ERC20PriceOracleReceiptVault.withdraw.t.sol
+++ b/test/src/concrete/vault/ERC20PriceOracleReceiptVault.withdraw.t.sol
@@ -341,7 +341,11 @@ contract ERC20PriceOracleReceiptVaultWithdrawTest is ERC20PriceOracleReceiptVaul
         priceTwo = bound(priceTwo, 1e18, 100e18);
         aliceDeposit = bound(aliceDeposit, 100e18, type(uint128).max);
 
+        // Start recording logs
+        vm.recordLogs();
         ERC20PriceOracleReceiptVault vault = createVault(iVaultOracle, "Alice", "Alice");
+
+        ReceiptContract receipt = getReceipt();
 
         // Set initial oracle price and deposit first half
         setVaultOraclePrice(priceOne);
@@ -360,6 +364,10 @@ contract ERC20PriceOracleReceiptVaultWithdrawTest is ERC20PriceOracleReceiptVaul
         // Assert receipt balance and vault state after first deposit
         uint256 expectedSharesOne = (aliceDeposit / 2).fixedPointMul(priceOne, Math.Rounding.Down);
         assertEq(vault.balanceOf(alice), expectedSharesOne);
+
+        // Check receipt balance
+        uint256 receiptBalance = receipt.balanceOf(alice, priceOne);
+        assertEq(receiptBalance, expectedSharesOne);
 
         // Set new oracle price and deposit second half
         setVaultOraclePrice(priceTwo);


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
test to show that the

oracle can mint (both mint and deposit need to be tested) several different receipt IDs by changing its price
the oracle price changes again without minting
burns (both withdraw and redeem need to be tested) cannot be done at the new oracle price, and must always be done for historical receipt prices only (check amounts, so that burn amounts and prices are 1:1 with each of the previous prices)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add a new test
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
