### PR TITLE
add token topology NatSpec to IReceiptVaultV3

### DIFF
--- a/src/interface/IReceiptVaultV3.sol
+++ b/src/interface/IReceiptVaultV3.sol
@@ -12,15 +12,19 @@ import {IReceiptV3} from "./IReceiptV3.sol";
 ///
 /// A single deposit creates positions at three addresses:
 /// - Receipt (ERC-1155): Proof of deposit. One ID per deposit; required for
-///   withdrawal.
+///   withdrawal. Each receipt maps 1:1 to a historical deposit of N shares.
 /// - ReceiptVault (ERC-20): Fungible vault shares. Represents pro-rata claim
-///   on the vault's underlying assets.
+///   on the vault's underlying assets. This is the primary value display for
+///   UIs.
 /// - WrappedTokenVault (ERC-4626, optional): Wraps receipt-vault shares;
 ///   captures rebases in share price rather than supply.
 ///
 /// To withdraw underlying assets, a holder must burn both the receipt
 /// (ERC-1155 at the specific deposit ID) and the shares (ERC-20). The receipt
 /// is the audit-trail proof; the shares are the value claim.
+///
+/// For UIs: Display the ERC-20 share balance as the primary value. List the
+/// receipt IDs as a "deposit record" showing the historical deposit amount.
 interface IReceiptVaultV3 is IReceiptVaultV1 {
     /// @return The `IReceiptV3` contract that is the receipt for this vault.
     function receipt() external view returns (IReceiptV3);

--- a/src/interface/IReceiptVaultV3.sol
+++ b/src/interface/IReceiptVaultV3.sol
@@ -9,6 +9,18 @@ import {IReceiptV3} from "./IReceiptV3.sol";
 /// @notice The `IReceiptVaultV3` interface extends `IReceiptVaultV1` with a
 /// getter for the `receipt` contract. Otherwise it is identical to
 /// `IReceiptVaultV1`.
+///
+/// A single deposit creates positions at three addresses:
+/// - Receipt (ERC-1155): Proof of deposit. One ID per deposit; required for
+///   withdrawal.
+/// - ReceiptVault (ERC-20): Fungible vault shares. Represents pro-rata claim
+///   on the vault's underlying assets.
+/// - WrappedTokenVault (ERC-4626, optional): Wraps receipt-vault shares;
+///   captures rebases in share price rather than supply.
+///
+/// To withdraw underlying assets, a holder must burn both the receipt
+/// (ERC-1155 at the specific deposit ID) and the shares (ERC-20). The receipt
+/// is the audit-trail proof; the shares are the value claim.
 interface IReceiptVaultV3 is IReceiptVaultV1 {
     /// @return The `IReceiptV3` contract that is the receipt for this vault.
     function receipt() external view returns (IReceiptV3);


### PR DESCRIPTION
## Summary
- Document the three-address model (receipt ERC-1155, receipt vault ERC-20, wrapped vault ERC-4626) on `IReceiptVaultV3`
- Document that withdrawal requires burning both receipt and shares

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how a single deposit maps to three tokenized positions (receipt tokens, fungible share balance, and optional vault-tracking tokens).
  * Explained withdrawal requirements: burning the specific receipt record plus the corresponding share balance to redeem value.
  * Added UI guidance: show the fungible share balance as primary value and list receipt IDs as deposit audit records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->