### PR TITLE
add PythOracle tests

### DIFF
--- a/test/src/concrete/oracle/PythOracle.t.sol
+++ b/test/src/concrete/oracle/PythOracle.t.sol
@@ -16,7 +16,9 @@ contract PythOracleTest is Test {
 
     function buildOracle() internal returns (PythOracle) {
         vm.etch(MOCK_PYTH, hex"00");
-        return new PythOracle(PythOracleConfig({priceFeedId: FEED_ID, staleAfter: STALE_AFTER, pythContract: IPyth(MOCK_PYTH)}));
+        return new PythOracle(
+            PythOracleConfig({priceFeedId: FEED_ID, staleAfter: STALE_AFTER, pythContract: IPyth(MOCK_PYTH)})
+        );
     }
 
     function mockPrice(int64 price, uint64 conf, int32 expo) internal {

--- a/test/src/concrete/oracle/PythOracle.t.sol
+++ b/test/src/concrete/oracle/PythOracle.t.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+import {PythOracle, PythOracleConfig, NonPositivePrice} from "src/concrete/oracle/PythOracle.sol";
+import {IPyth} from "pyth-sdk/IPyth.sol";
+import {PythStructs} from "pyth-sdk/PythStructs.sol";
+
+contract PythOracleTest is Test {
+    receive() external payable {}
+
+    address constant MOCK_PYTH = address(uint160(uint256(keccak256("MOCK_PYTH"))));
+    bytes32 constant FEED_ID = bytes32(uint256(1));
+    uint256 constant STALE_AFTER = 60;
+
+    function buildOracle() internal returns (PythOracle) {
+        vm.etch(MOCK_PYTH, hex"00");
+        return new PythOracle(PythOracleConfig({priceFeedId: FEED_ID, staleAfter: STALE_AFTER, pythContract: IPyth(MOCK_PYTH)}));
+    }
+
+    function mockPrice(int64 price, uint64 conf, int32 expo) internal {
+        PythStructs.Price memory priceData =
+            PythStructs.Price({price: price, conf: conf, expo: expo, publishTime: block.timestamp});
+        vm.mockCall(
+            MOCK_PYTH,
+            abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, FEED_ID, STALE_AFTER),
+            abi.encode(priceData)
+        );
+    }
+
+    /// A normal price with zero confidence returns the price as 18-decimal.
+    function testPriceNormalZeroConf() external {
+        PythOracle oracle = buildOracle();
+        // price = 100, conf = 0, expo = -2 => 1.00 => 1e18
+        mockPrice(100, 0, -2);
+        assertEq(oracle.price(), 1e18);
+    }
+
+    /// Confidence is subtracted from price for a conservative estimate.
+    function testPriceSubtractsConfidence() external {
+        PythOracle oracle = buildOracle();
+        // price = 1000, conf = 50, expo = -3 => (1000 - 50) * 1e-3 = 0.95 => 0.95e18
+        mockPrice(1000, 50, -3);
+        assertEq(oracle.price(), 0.95e18);
+    }
+
+    /// Reverts when confidence >= price (conservative price <= 0).
+    function testRevertsNonPositivePrice() external {
+        PythOracle oracle = buildOracle();
+        // price = 100, conf = 100, expo = -2 => conservative = 0
+        mockPrice(100, 100, -2);
+        vm.expectRevert(abi.encodeWithSelector(NonPositivePrice.selector, int256(0)));
+        oracle.price();
+    }
+
+    /// Reverts when confidence exceeds price (conservative price < 0).
+    function testRevertsNegativeConservativePrice() external {
+        PythOracle oracle = buildOracle();
+        // price = 50, conf = 100, expo = -2 => conservative = -50
+        mockPrice(50, 100, -2);
+        vm.expectRevert(abi.encodeWithSelector(NonPositivePrice.selector, int256(-50)));
+        oracle.price();
+    }
+
+    /// Positive exponent scales up correctly.
+    function testPricePositiveExponent() external {
+        PythOracle oracle = buildOracle();
+        // price = 5, conf = 0, expo = 2 => 500 => 500e18
+        mockPrice(5, 0, 2);
+        assertEq(oracle.price(), 500e18);
+    }
+
+    /// Large price with negative exponent.
+    function testPriceLargeWithNegativeExponent() external {
+        PythOracle oracle = buildOracle();
+        // price = 350000, conf = 0, expo = -2 => 3500.00 => 3500e18
+        mockPrice(350000, 0, -2);
+        assertEq(oracle.price(), 3500e18);
+    }
+
+    /// Construction emits event and sets immutables.
+    function testConstruction() external {
+        PythOracle oracle = buildOracle();
+        assertEq(oracle.I_PRICE_FEED_ID(), FEED_ID);
+        assertEq(oracle.I_STALE_AFTER(), STALE_AFTER);
+        assertEq(address(oracle.I_PYTH_CONTRACT()), MOCK_PYTH);
+    }
+}

--- a/test/src/concrete/oracle/PythOracle.t.sol
+++ b/test/src/concrete/oracle/PythOracle.t.sol
@@ -82,8 +82,8 @@ contract PythOracleTest is Test {
     /// Construction emits event and sets immutables.
     function testConstruction() external {
         PythOracle oracle = buildOracle();
-        assertEq(oracle.I_PRICE_FEED_ID(), FEED_ID);
-        assertEq(oracle.I_STALE_AFTER(), STALE_AFTER);
-        assertEq(address(oracle.I_PYTH_CONTRACT()), MOCK_PYTH);
+        assertEq(oracle.iPriceFeedId(), FEED_ID);
+        assertEq(oracle.iStaleAfter(), STALE_AFTER);
+        assertEq(address(oracle.iPythContract()), MOCK_PYTH);
     }
 }


### PR DESCRIPTION
## Summary
- Add 7 tests for `PythOracle` covering price conversion, confidence subtraction, non-positive price revert, positive/negative exponents, and constructor immutables
- Uses `vm.mockCall` for the Pyth contract — no mock contract needed

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for the price oracle covering: decimal scaling to 18 decimals, confidence-adjusted pricing (including subtraction of confidence), explicit revert conditions when conservative price is non-positive (with revert payload checks), positive and large-magnitude negative exponent handling, and constructor/configuration validations using a mocked external price feed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->