### PR TITLE
fix flaky authorize unauthorized test

### DIFF
--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.authorize.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.authorize.t.sol
@@ -39,6 +39,9 @@ contract OffchainAssetReceiptVaultAuthorizerV1AuthorizeTest is OffchainAssetRece
         bytes memory data
     ) external {
         vm.assume(initialAdmin != address(0));
+        // The sender must not be the admin, otherwise they may hold roles
+        // that make the authorize call succeed instead of reverting.
+        vm.assume(sender != initialAdmin);
         OffchainAssetReceiptVaultAuthorizerV1 authorizer = newAuthorizer(initialAdmin);
 
         checkDefaultOffchainAssetReceiptVaultAuthorizerV1AuthorizeUnauthorized(


### PR DESCRIPTION
## Summary
- Ensure fuzzed `sender != initialAdmin` so the admin's roles don't make the call succeed when it should revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)