### PR TITLE
change _initialize to accept decoded config struct

### DIFF
--- a/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.sol
+++ b/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.sol
@@ -58,15 +58,13 @@ contract OffchainAssetReceiptVaultAuthorizerV1 is IAuthorizeV1, ICloneableV2, Ac
 
     /// @inheritdoc ICloneableV2
     function initialize(bytes memory data) external virtual override initializer returns (bytes32) {
-        return _initialize(data);
+        return _initialize(abi.decode(data, (OffchainAssetReceiptVaultAuthorizerV1Config)));
     }
 
     /// Initialization logic without the initializer modifier so inheriting
-    /// contracts can access it and be the initializer.
-    function _initialize(bytes memory data) internal returns (bytes32) {
-        OffchainAssetReceiptVaultAuthorizerV1Config memory config =
-            abi.decode(data, (OffchainAssetReceiptVaultAuthorizerV1Config));
-
+    /// contracts can access it and be the initializer. Accepts the decoded
+    /// config so child contracts don't need to double-decode.
+    function _initialize(OffchainAssetReceiptVaultAuthorizerV1Config memory config) internal returns (bytes32) {
         __AccessControl_init();
 
         // The config admin MUST be set.

--- a/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.sol
+++ b/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.sol
@@ -214,7 +214,7 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1 is OffchainAssetReceip
             config.maxSharesSupply
         );
         // Owner of the authorizer is also the initial admin for role management.
-        super._initialize(abi.encode(OffchainAssetReceiptVaultAuthorizerV1Config({initialAdmin: config.owner})));
+        super._initialize(OffchainAssetReceiptVaultAuthorizerV1Config({initialAdmin: config.owner}));
 
         // By revoking the deposit and withdraw admin roles we ensure that there
         // can never be any addresses with deposit or withdraw roles. This


### PR DESCRIPTION
## Summary
- `_initialize(bytes memory data)` -> `_initialize(OffchainAssetReceiptVaultAuthorizerV1Config memory config)`
- Public `initialize(bytes)` decodes then calls `_initialize(config)`
- `OffchainAssetReceiptVaultPaymentMintAuthorizerV1` no longer re-encodes just to pass bytes

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized initialization handling by restructuring how configuration data is processed and passed to the base initializer, improving code clarity and reducing redundant encoding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->