### PR TITLE
add V1 and V2 interfaces for deployers and oracles

### DIFF
--- a/src/concrete/deploy/ERC20PriceOracleReceiptVaultCloneDeployer.sol
+++ b/src/concrete/deploy/ERC20PriceOracleReceiptVaultCloneDeployer.sol
@@ -10,6 +10,8 @@ import {
     InitializeVaultFailed
 } from "../../error/ErrDeployer.sol";
 import {Clones} from "openzeppelin-contracts/contracts/proxy/Clones.sol";
+import {IERC165} from "openzeppelin-contracts/contracts/utils/introspection/IERC165.sol";
+import {IERC20PriceOracleReceiptVaultCloneDeployerV2} from "../../interface/IERC20PriceOracleReceiptVaultCloneDeployerV2.sol";
 import {Receipt, ICLONEABLE_V2_SUCCESS} from "../receipt/Receipt.sol";
 import {
     ERC20PriceOracleReceiptVault,
@@ -30,7 +32,12 @@ struct ERC20PriceOracleReceiptVaultCloneDeployerConfig {
 /// @title ERC20PriceOracleReceiptVaultCloneDeployer
 /// Deploys ERC20PriceOracleReceiptVault contracts as minimal proxy contracts
 /// and handles the necessary initialization atomically.
-contract ERC20PriceOracleReceiptVaultCloneDeployer {
+contract ERC20PriceOracleReceiptVaultCloneDeployer is IERC165 {
+    /// @inheritdoc IERC165
+    function supportsInterface(bytes4 interfaceId) public pure override returns (bool) {
+        return interfaceId == type(IERC20PriceOracleReceiptVaultCloneDeployerV2).interfaceId
+            || interfaceId == type(IERC165).interfaceId;
+    }
     /// Emitted when a new deployment is successfully initialized.
     /// @param sender The address that initiated the deployment.
     /// @param erc20PriceOracleReceiptVault The address of the deployed

--- a/src/concrete/deploy/ERC20PriceOracleReceiptVaultCloneDeployer.sol
+++ b/src/concrete/deploy/ERC20PriceOracleReceiptVaultCloneDeployer.sol
@@ -11,7 +11,9 @@ import {
 } from "../../error/ErrDeployer.sol";
 import {Clones} from "openzeppelin-contracts/contracts/proxy/Clones.sol";
 import {IERC165} from "openzeppelin-contracts/contracts/utils/introspection/IERC165.sol";
-import {IERC20PriceOracleReceiptVaultCloneDeployerV2} from "../../interface/IERC20PriceOracleReceiptVaultCloneDeployerV2.sol";
+import {
+    IERC20PriceOracleReceiptVaultCloneDeployerV2
+} from "../../interface/IERC20PriceOracleReceiptVaultCloneDeployerV2.sol";
 import {Receipt, ICLONEABLE_V2_SUCCESS} from "../receipt/Receipt.sol";
 import {
     ERC20PriceOracleReceiptVault,

--- a/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol
+++ b/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol
@@ -7,6 +7,8 @@ import {OffchainAssetReceiptVault, OffchainAssetReceiptVaultConfigV2} from "../v
 import {IBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol";
 import {UpgradeableBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import {BeaconProxy} from "openzeppelin-contracts/contracts/proxy/beacon/BeaconProxy.sol";
+import {IERC165} from "openzeppelin-contracts/contracts/utils/introspection/IERC165.sol";
+import {IOffchainAssetReceiptVaultBeaconSetDeployerV2} from "../../interface/IOffchainAssetReceiptVaultBeaconSetDeployerV2.sol";
 import {
     ZeroReceiptImplementation,
     ZeroVaultImplementation,
@@ -33,7 +35,12 @@ struct OffchainAssetReceiptVaultBeaconSetDeployerConfig {
 /// @title OffchainAssetReceiptVaultBeaconSetDeployer
 /// Deploys OffchainAssetReceiptVault contracts using beacon proxies and
 /// handles the necessary initialization atomically.
-contract OffchainAssetReceiptVaultBeaconSetDeployer {
+contract OffchainAssetReceiptVaultBeaconSetDeployer is IERC165 {
+    /// @inheritdoc IERC165
+    function supportsInterface(bytes4 interfaceId) public pure override returns (bool) {
+        return interfaceId == type(IOffchainAssetReceiptVaultBeaconSetDeployerV2).interfaceId
+            || interfaceId == type(IERC165).interfaceId;
+    }
     /// Emitted when a new deployment is successfully initialized.
     /// @param sender The address that initiated the deployment.
     /// @param offchainAssetReceiptVault The address of the deployed

--- a/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol
+++ b/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol
@@ -8,7 +8,9 @@ import {IBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol
 import {UpgradeableBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import {BeaconProxy} from "openzeppelin-contracts/contracts/proxy/beacon/BeaconProxy.sol";
 import {IERC165} from "openzeppelin-contracts/contracts/utils/introspection/IERC165.sol";
-import {IOffchainAssetReceiptVaultBeaconSetDeployerV2} from "../../interface/IOffchainAssetReceiptVaultBeaconSetDeployerV2.sol";
+import {
+    IOffchainAssetReceiptVaultBeaconSetDeployerV2
+} from "../../interface/IOffchainAssetReceiptVaultBeaconSetDeployerV2.sol";
 import {
     ZeroReceiptImplementation,
     ZeroVaultImplementation,

--- a/src/interface/IERC20PriceOracleReceiptVaultCloneDeployerV1.sol
+++ b/src/interface/IERC20PriceOracleReceiptVaultCloneDeployerV1.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.0;
+
+import {
+    ERC20PriceOracleReceiptVault,
+    ERC20PriceOracleReceiptVaultConfigV2
+} from "../concrete/vault/ERC20PriceOracleReceiptVault.sol";
+
+/// @title IERC20PriceOracleReceiptVaultCloneDeployerV1
+/// @notice V1 interface for the ERC20PriceOracleReceiptVaultCloneDeployer.
+/// Uses the original I_ naming convention. Deployed contracts on-chain have
+/// this ABI.
+interface IERC20PriceOracleReceiptVaultCloneDeployerV1 {
+    /// @return The address of the Receipt implementation contract.
+    // solhint-disable-next-line func-name-mixedcase
+    function I_RECEIPT_IMPLEMENTATION() external view returns (address);
+
+    /// @return The address of the ERC20PriceOracleReceiptVault implementation.
+    // solhint-disable-next-line func-name-mixedcase
+    function I_ERC20_PRICE_ORACLE_RECEIPT_VAULT_IMPLEMENTATION() external view returns (address);
+
+    /// @notice Deploy a new ERC20PriceOracleReceiptVault with its Receipt.
+    function newERC20PriceOracleReceiptVault(ERC20PriceOracleReceiptVaultConfigV2 memory config)
+        external
+        returns (ERC20PriceOracleReceiptVault);
+}

--- a/src/interface/IERC20PriceOracleReceiptVaultCloneDeployerV1.sol
+++ b/src/interface/IERC20PriceOracleReceiptVaultCloneDeployerV1.sol
@@ -13,11 +13,13 @@ import {
 /// this ABI.
 interface IERC20PriceOracleReceiptVaultCloneDeployerV1 {
     /// @return The address of the Receipt implementation contract.
-    // solhint-disable-next-line func-name-mixedcase
+    // Matches deployed on-chain ABI.
+    //slither-disable-next-line naming-convention
     function I_RECEIPT_IMPLEMENTATION() external view returns (address);
 
     /// @return The address of the ERC20PriceOracleReceiptVault implementation.
-    // solhint-disable-next-line func-name-mixedcase
+    // Matches deployed on-chain ABI.
+    //slither-disable-next-line naming-convention
     function I_ERC20_PRICE_ORACLE_RECEIPT_VAULT_IMPLEMENTATION() external view returns (address);
 
     /// @notice Deploy a new ERC20PriceOracleReceiptVault with its Receipt.

--- a/src/interface/IERC20PriceOracleReceiptVaultCloneDeployerV2.sol
+++ b/src/interface/IERC20PriceOracleReceiptVaultCloneDeployerV2.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.0;
+
+import {
+    ERC20PriceOracleReceiptVault,
+    ERC20PriceOracleReceiptVaultConfigV2
+} from "../concrete/vault/ERC20PriceOracleReceiptVault.sol";
+
+/// @title IERC20PriceOracleReceiptVaultCloneDeployerV2
+/// @notice V2 interface for the ERC20PriceOracleReceiptVaultCloneDeployer.
+/// Uses camelCase i prefix. New deployments use this ABI.
+interface IERC20PriceOracleReceiptVaultCloneDeployerV2 {
+    /// @return The address of the Receipt implementation contract.
+    function iReceiptImplementation() external view returns (address);
+
+    /// @return The address of the ERC20PriceOracleReceiptVault implementation.
+    function iErc20PriceOracleReceiptVaultImplementation() external view returns (address);
+
+    /// @notice Deploy a new ERC20PriceOracleReceiptVault with its Receipt.
+    function newERC20PriceOracleReceiptVault(ERC20PriceOracleReceiptVaultConfigV2 memory config)
+        external
+        returns (ERC20PriceOracleReceiptVault);
+}

--- a/src/interface/IFtsoV2LTSFeedOracleV1.sol
+++ b/src/interface/IFtsoV2LTSFeedOracleV1.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.0;
+
+/// @title IFtsoV2LTSFeedOracleV1
+/// @notice V1 interface for FtsoV2LTSFeedOracle. Uses the original I_ naming
+/// convention. Deployed contracts on-chain have this ABI.
+interface IFtsoV2LTSFeedOracleV1 {
+    // solhint-disable-next-line func-name-mixedcase
+    function I_FEED_ID() external view returns (bytes21);
+    // solhint-disable-next-line func-name-mixedcase
+    function I_STALE_AFTER() external view returns (uint256);
+}

--- a/src/interface/IFtsoV2LTSFeedOracleV1.sol
+++ b/src/interface/IFtsoV2LTSFeedOracleV1.sol
@@ -6,8 +6,10 @@ pragma solidity ^0.8.0;
 /// @notice V1 interface for FtsoV2LTSFeedOracle. Uses the original I_ naming
 /// convention. Deployed contracts on-chain have this ABI.
 interface IFtsoV2LTSFeedOracleV1 {
-    // solhint-disable-next-line func-name-mixedcase
+    // Matches deployed on-chain ABI.
+    //slither-disable-next-line naming-convention
     function I_FEED_ID() external view returns (bytes21);
-    // solhint-disable-next-line func-name-mixedcase
+    // Matches deployed on-chain ABI.
+    //slither-disable-next-line naming-convention
     function I_STALE_AFTER() external view returns (uint256);
 }

--- a/src/interface/IFtsoV2LTSFeedOracleV2.sol
+++ b/src/interface/IFtsoV2LTSFeedOracleV2.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.0;
+
+/// @title IFtsoV2LTSFeedOracleV2
+/// @notice V2 interface for FtsoV2LTSFeedOracle. Uses camelCase i prefix.
+/// New deployments use this ABI.
+interface IFtsoV2LTSFeedOracleV2 {
+    function iFeedId() external view returns (bytes21);
+    function iStaleAfter() external view returns (uint256);
+}

--- a/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV1.sol
+++ b/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV1.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.0;
+
+import {IBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol";
+import {OffchainAssetReceiptVault} from "../concrete/vault/OffchainAssetReceiptVault.sol";
+import {OffchainAssetReceiptVaultConfigV2} from "../concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol";
+
+/// @title IOffchainAssetReceiptVaultBeaconSetDeployerV1
+/// @notice V1 interface for the OffchainAssetReceiptVaultBeaconSetDeployer.
+/// Uses the original I_ naming convention for public immutables. Deployed
+/// contracts on-chain have this ABI.
+interface IOffchainAssetReceiptVaultBeaconSetDeployerV1 {
+    /// @return The beacon for the Receipt implementation contracts.
+    // solhint-disable-next-line func-name-mixedcase
+    function I_RECEIPT_BEACON() external view returns (IBeacon);
+
+    /// @return The beacon for the OffchainAssetReceiptVault implementation
+    /// contracts.
+    // solhint-disable-next-line func-name-mixedcase
+    function I_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON() external view returns (IBeacon);
+
+    /// @notice Deploy a new OffchainAssetReceiptVault with its Receipt.
+    function newOffchainAssetReceiptVault(OffchainAssetReceiptVaultConfigV2 memory config)
+        external
+        returns (OffchainAssetReceiptVault);
+}

--- a/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV1.sol
+++ b/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV1.sol
@@ -3,8 +3,7 @@
 pragma solidity ^0.8.0;
 
 import {IBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol";
-import {OffchainAssetReceiptVault} from "../concrete/vault/OffchainAssetReceiptVault.sol";
-import {OffchainAssetReceiptVaultConfigV2} from "../concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol";
+import {OffchainAssetReceiptVault, OffchainAssetReceiptVaultConfigV2} from "../concrete/vault/OffchainAssetReceiptVault.sol";
 
 /// @title IOffchainAssetReceiptVaultBeaconSetDeployerV1
 /// @notice V1 interface for the OffchainAssetReceiptVaultBeaconSetDeployer.

--- a/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV1.sol
+++ b/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV1.sol
@@ -3,7 +3,10 @@
 pragma solidity ^0.8.0;
 
 import {IBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol";
-import {OffchainAssetReceiptVault, OffchainAssetReceiptVaultConfigV2} from "../concrete/vault/OffchainAssetReceiptVault.sol";
+import {
+    OffchainAssetReceiptVault,
+    OffchainAssetReceiptVaultConfigV2
+} from "../concrete/vault/OffchainAssetReceiptVault.sol";
 
 /// @title IOffchainAssetReceiptVaultBeaconSetDeployerV1
 /// @notice V1 interface for the OffchainAssetReceiptVaultBeaconSetDeployer.

--- a/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV1.sol
+++ b/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV1.sol
@@ -12,12 +12,14 @@ import {OffchainAssetReceiptVaultConfigV2} from "../concrete/deploy/OffchainAsse
 /// contracts on-chain have this ABI.
 interface IOffchainAssetReceiptVaultBeaconSetDeployerV1 {
     /// @return The beacon for the Receipt implementation contracts.
-    // solhint-disable-next-line func-name-mixedcase
+    // Matches deployed on-chain ABI.
+    //slither-disable-next-line naming-convention
     function I_RECEIPT_BEACON() external view returns (IBeacon);
 
     /// @return The beacon for the OffchainAssetReceiptVault implementation
     /// contracts.
-    // solhint-disable-next-line func-name-mixedcase
+    // Matches deployed on-chain ABI.
+    //slither-disable-next-line naming-convention
     function I_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON() external view returns (IBeacon);
 
     /// @notice Deploy a new OffchainAssetReceiptVault with its Receipt.

--- a/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV2.sol
+++ b/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV2.sol
@@ -3,7 +3,10 @@
 pragma solidity ^0.8.0;
 
 import {IBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol";
-import {OffchainAssetReceiptVault, OffchainAssetReceiptVaultConfigV2} from "../concrete/vault/OffchainAssetReceiptVault.sol";
+import {
+    OffchainAssetReceiptVault,
+    OffchainAssetReceiptVaultConfigV2
+} from "../concrete/vault/OffchainAssetReceiptVault.sol";
 
 /// @title IOffchainAssetReceiptVaultBeaconSetDeployerV2
 /// @notice V2 interface for the OffchainAssetReceiptVaultBeaconSetDeployer.

--- a/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV2.sol
+++ b/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV2.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.0;
+
+import {IBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol";
+import {OffchainAssetReceiptVault} from "../concrete/vault/OffchainAssetReceiptVault.sol";
+import {OffchainAssetReceiptVaultConfigV2} from "../concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol";
+
+/// @title IOffchainAssetReceiptVaultBeaconSetDeployerV2
+/// @notice V2 interface for the OffchainAssetReceiptVaultBeaconSetDeployer.
+/// Uses camelCase i prefix for public immutables. New deployments use this ABI.
+interface IOffchainAssetReceiptVaultBeaconSetDeployerV2 {
+    /// @return The beacon for the Receipt implementation contracts.
+    function iReceiptBeacon() external view returns (IBeacon);
+
+    /// @return The beacon for the OffchainAssetReceiptVault implementation
+    /// contracts.
+    function iOffchainAssetReceiptVaultBeacon() external view returns (IBeacon);
+
+    /// @notice Deploy a new OffchainAssetReceiptVault with its Receipt.
+    function newOffchainAssetReceiptVault(OffchainAssetReceiptVaultConfigV2 memory config)
+        external
+        returns (OffchainAssetReceiptVault);
+}

--- a/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV2.sol
+++ b/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV2.sol
@@ -3,8 +3,7 @@
 pragma solidity ^0.8.0;
 
 import {IBeacon} from "openzeppelin-contracts/contracts/proxy/beacon/IBeacon.sol";
-import {OffchainAssetReceiptVault} from "../concrete/vault/OffchainAssetReceiptVault.sol";
-import {OffchainAssetReceiptVaultConfigV2} from "../concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol";
+import {OffchainAssetReceiptVault, OffchainAssetReceiptVaultConfigV2} from "../concrete/vault/OffchainAssetReceiptVault.sol";
 
 /// @title IOffchainAssetReceiptVaultBeaconSetDeployerV2
 /// @notice V2 interface for the OffchainAssetReceiptVaultBeaconSetDeployer.

--- a/src/interface/IPythOracleV1.sol
+++ b/src/interface/IPythOracleV1.sol
@@ -8,10 +8,13 @@ import {IPyth} from "pyth-sdk/IPyth.sol";
 /// @notice V1 interface for PythOracle. Uses the original I_ naming
 /// convention. Deployed contracts on-chain have this ABI.
 interface IPythOracleV1 {
-    // solhint-disable-next-line func-name-mixedcase
+    // Matches deployed on-chain ABI.
+    //slither-disable-next-line naming-convention
     function I_PRICE_FEED_ID() external view returns (bytes32);
-    // solhint-disable-next-line func-name-mixedcase
+    // Matches deployed on-chain ABI.
+    //slither-disable-next-line naming-convention
     function I_STALE_AFTER() external view returns (uint256);
-    // solhint-disable-next-line func-name-mixedcase
+    // Matches deployed on-chain ABI.
+    //slither-disable-next-line naming-convention
     function I_PYTH_CONTRACT() external view returns (IPyth);
 }

--- a/src/interface/IPythOracleV1.sol
+++ b/src/interface/IPythOracleV1.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.0;
+
+import {IPyth} from "pyth-sdk/IPyth.sol";
+
+/// @title IPythOracleV1
+/// @notice V1 interface for PythOracle. Uses the original I_ naming
+/// convention. Deployed contracts on-chain have this ABI.
+interface IPythOracleV1 {
+    // solhint-disable-next-line func-name-mixedcase
+    function I_PRICE_FEED_ID() external view returns (bytes32);
+    // solhint-disable-next-line func-name-mixedcase
+    function I_STALE_AFTER() external view returns (uint256);
+    // solhint-disable-next-line func-name-mixedcase
+    function I_PYTH_CONTRACT() external view returns (IPyth);
+}

--- a/src/interface/IPythOracleV2.sol
+++ b/src/interface/IPythOracleV2.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.0;
+
+import {IPyth} from "pyth-sdk/IPyth.sol";
+
+/// @title IPythOracleV2
+/// @notice V2 interface for PythOracle. Uses camelCase i prefix. New
+/// deployments use this ABI.
+interface IPythOracleV2 {
+    function iPriceFeedId() external view returns (bytes32);
+    function iStaleAfter() external view returns (uint256);
+    function iPythContract() external view returns (IPyth);
+}

--- a/test/src/concrete/deploy/ERC20PriceOracleReceiptVaultCloneDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/ERC20PriceOracleReceiptVaultCloneDeployer.construct.t.sol
@@ -8,6 +8,7 @@ import {
     ERC20PriceOracleReceiptVaultCloneDeployer,
     ERC20PriceOracleReceiptVaultCloneDeployerConfig
 } from "src/concrete/deploy/ERC20PriceOracleReceiptVaultCloneDeployer.sol";
+import {IERC20PriceOracleReceiptVaultCloneDeployerV2} from "src/interface/IERC20PriceOracleReceiptVaultCloneDeployerV2.sol";
 import {ZeroReceiptImplementation, ZeroVaultImplementation} from "src/error/ErrDeployer.sol";
 
 contract ERC20PriceOracleReceiptVaultCloneDeployerConstructTest is Test {
@@ -44,9 +45,10 @@ contract ERC20PriceOracleReceiptVaultCloneDeployerConstructTest is Test {
 
         ERC20PriceOracleReceiptVaultCloneDeployer deployer = new ERC20PriceOracleReceiptVaultCloneDeployer(config);
 
-        vm.assertEq(deployer.iReceiptImplementation(), config.receiptImplementation);
+        IERC20PriceOracleReceiptVaultCloneDeployerV2 iDeployer = IERC20PriceOracleReceiptVaultCloneDeployerV2(address(deployer));
+        vm.assertEq(iDeployer.iReceiptImplementation(), config.receiptImplementation);
         vm.assertEq(
-            deployer.iErc20PriceOracleReceiptVaultImplementation(), config.erc20PriceOracleReceiptVaultImplementation
+            iDeployer.iErc20PriceOracleReceiptVaultImplementation(), config.erc20PriceOracleReceiptVaultImplementation
         );
     }
 }

--- a/test/src/concrete/deploy/ERC20PriceOracleReceiptVaultCloneDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/ERC20PriceOracleReceiptVaultCloneDeployer.construct.t.sol
@@ -8,7 +8,9 @@ import {
     ERC20PriceOracleReceiptVaultCloneDeployer,
     ERC20PriceOracleReceiptVaultCloneDeployerConfig
 } from "src/concrete/deploy/ERC20PriceOracleReceiptVaultCloneDeployer.sol";
-import {IERC20PriceOracleReceiptVaultCloneDeployerV2} from "src/interface/IERC20PriceOracleReceiptVaultCloneDeployerV2.sol";
+import {
+    IERC20PriceOracleReceiptVaultCloneDeployerV2
+} from "src/interface/IERC20PriceOracleReceiptVaultCloneDeployerV2.sol";
 import {ZeroReceiptImplementation, ZeroVaultImplementation} from "src/error/ErrDeployer.sol";
 
 contract ERC20PriceOracleReceiptVaultCloneDeployerConstructTest is Test {
@@ -45,7 +47,8 @@ contract ERC20PriceOracleReceiptVaultCloneDeployerConstructTest is Test {
 
         ERC20PriceOracleReceiptVaultCloneDeployer deployer = new ERC20PriceOracleReceiptVaultCloneDeployer(config);
 
-        IERC20PriceOracleReceiptVaultCloneDeployerV2 iDeployer = IERC20PriceOracleReceiptVaultCloneDeployerV2(address(deployer));
+        IERC20PriceOracleReceiptVaultCloneDeployerV2 iDeployer =
+            IERC20PriceOracleReceiptVaultCloneDeployerV2(address(deployer));
         vm.assertEq(iDeployer.iReceiptImplementation(), config.receiptImplementation);
         vm.assertEq(
             iDeployer.iErc20PriceOracleReceiptVaultImplementation(), config.erc20PriceOracleReceiptVaultImplementation

--- a/test/src/concrete/deploy/ERC20PriceOracleReceiptVaultCloneDeployer.ierc165.t.sol
+++ b/test/src/concrete/deploy/ERC20PriceOracleReceiptVaultCloneDeployer.ierc165.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+
+import {IERC165} from "openzeppelin-contracts/contracts/utils/introspection/IERC165.sol";
+import {
+    ERC20PriceOracleReceiptVaultCloneDeployer,
+    ERC20PriceOracleReceiptVaultCloneDeployerConfig
+} from "src/concrete/deploy/ERC20PriceOracleReceiptVaultCloneDeployer.sol";
+import {
+    IERC20PriceOracleReceiptVaultCloneDeployerV2
+} from "src/interface/IERC20PriceOracleReceiptVaultCloneDeployerV2.sol";
+import {ERC20PriceOracleReceiptVault} from "src/concrete/vault/ERC20PriceOracleReceiptVault.sol";
+import {Receipt as ReceiptContract} from "src/concrete/receipt/Receipt.sol";
+
+contract ERC20PriceOracleReceiptVaultCloneDeployerIERC165Test is Test {
+    function testERC20PriceOracleReceiptVaultCloneDeployerIERC165(bytes4 badInterfaceId) external {
+        vm.assume(badInterfaceId != type(IERC165).interfaceId);
+        vm.assume(badInterfaceId != type(IERC20PriceOracleReceiptVaultCloneDeployerV2).interfaceId);
+
+        ERC20PriceOracleReceiptVaultCloneDeployer deployer = new ERC20PriceOracleReceiptVaultCloneDeployer(
+            ERC20PriceOracleReceiptVaultCloneDeployerConfig({
+                receiptImplementation: address(new ReceiptContract()),
+                erc20PriceOracleReceiptVaultImplementation: address(new ERC20PriceOracleReceiptVault())
+            })
+        );
+
+        assertTrue(deployer.supportsInterface(type(IERC165).interfaceId));
+        assertTrue(deployer.supportsInterface(type(IERC20PriceOracleReceiptVaultCloneDeployerV2).interfaceId));
+        assertFalse(deployer.supportsInterface(badInterfaceId));
+    }
+}

--- a/test/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.construct.t.sol
@@ -8,6 +8,7 @@ import {
     OffchainAssetReceiptVaultBeaconSetDeployer,
     OffchainAssetReceiptVaultBeaconSetDeployerConfig
 } from "src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol";
+import {IOffchainAssetReceiptVaultBeaconSetDeployerV2} from "src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV2.sol";
 import {ZeroReceiptImplementation, ZeroVaultImplementation, ZeroBeaconOwner} from "src/error/ErrDeployer.sol";
 import {OffchainAssetReceiptVault} from "src/concrete/vault/OffchainAssetReceiptVault.sol";
 import {Receipt as ReceiptContract} from "src/concrete/receipt/Receipt.sol";
@@ -74,9 +75,10 @@ contract OffchainAssetReceiptVaultBeaconSetDeployerConstructTest is Test {
             })
         );
 
-        vm.assertEq(address(deployer.iReceiptBeacon().implementation()), address(initialReceiptImplementation));
+        IOffchainAssetReceiptVaultBeaconSetDeployerV2 iDeployer = IOffchainAssetReceiptVaultBeaconSetDeployerV2(address(deployer));
+        vm.assertEq(address(iDeployer.iReceiptBeacon().implementation()), address(initialReceiptImplementation));
         vm.assertEq(
-            address(deployer.iOffchainAssetReceiptVaultBeacon().implementation()),
+            address(iDeployer.iOffchainAssetReceiptVaultBeacon().implementation()),
             address(initialOffchainAssetReceiptVaultImplementation)
         );
     }

--- a/test/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.construct.t.sol
+++ b/test/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.construct.t.sol
@@ -8,7 +8,9 @@ import {
     OffchainAssetReceiptVaultBeaconSetDeployer,
     OffchainAssetReceiptVaultBeaconSetDeployerConfig
 } from "src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol";
-import {IOffchainAssetReceiptVaultBeaconSetDeployerV2} from "src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV2.sol";
+import {
+    IOffchainAssetReceiptVaultBeaconSetDeployerV2
+} from "src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV2.sol";
 import {ZeroReceiptImplementation, ZeroVaultImplementation, ZeroBeaconOwner} from "src/error/ErrDeployer.sol";
 import {OffchainAssetReceiptVault} from "src/concrete/vault/OffchainAssetReceiptVault.sol";
 import {Receipt as ReceiptContract} from "src/concrete/receipt/Receipt.sol";
@@ -75,7 +77,8 @@ contract OffchainAssetReceiptVaultBeaconSetDeployerConstructTest is Test {
             })
         );
 
-        IOffchainAssetReceiptVaultBeaconSetDeployerV2 iDeployer = IOffchainAssetReceiptVaultBeaconSetDeployerV2(address(deployer));
+        IOffchainAssetReceiptVaultBeaconSetDeployerV2 iDeployer =
+            IOffchainAssetReceiptVaultBeaconSetDeployerV2(address(deployer));
         vm.assertEq(address(iDeployer.iReceiptBeacon().implementation()), address(initialReceiptImplementation));
         vm.assertEq(
             address(iDeployer.iOffchainAssetReceiptVaultBeacon().implementation()),

--- a/test/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.ierc165.t.sol
+++ b/test/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.ierc165.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+
+import {IERC165} from "openzeppelin-contracts/contracts/utils/introspection/IERC165.sol";
+import {
+    OffchainAssetReceiptVaultBeaconSetDeployer,
+    OffchainAssetReceiptVaultBeaconSetDeployerConfig
+} from "src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol";
+import {
+    IOffchainAssetReceiptVaultBeaconSetDeployerV2
+} from "src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV2.sol";
+import {OffchainAssetReceiptVault} from "src/concrete/vault/OffchainAssetReceiptVault.sol";
+import {Receipt as ReceiptContract} from "src/concrete/receipt/Receipt.sol";
+
+contract OffchainAssetReceiptVaultBeaconSetDeployerIERC165Test is Test {
+    function testOffchainAssetReceiptVaultBeaconSetDeployerIERC165(bytes4 badInterfaceId) external {
+        vm.assume(badInterfaceId != type(IERC165).interfaceId);
+        vm.assume(badInterfaceId != type(IOffchainAssetReceiptVaultBeaconSetDeployerV2).interfaceId);
+
+        OffchainAssetReceiptVaultBeaconSetDeployer deployer = new OffchainAssetReceiptVaultBeaconSetDeployer(
+            OffchainAssetReceiptVaultBeaconSetDeployerConfig({
+                initialOwner: address(this),
+                initialReceiptImplementation: address(new ReceiptContract()),
+                initialOffchainAssetReceiptVaultImplementation: address(new OffchainAssetReceiptVault())
+            })
+        );
+
+        assertTrue(deployer.supportsInterface(type(IERC165).interfaceId));
+        assertTrue(deployer.supportsInterface(type(IOffchainAssetReceiptVaultBeaconSetDeployerV2).interfaceId));
+        assertFalse(deployer.supportsInterface(badInterfaceId));
+    }
+}

--- a/test/src/concrete/oracle/PythOracle.t.sol
+++ b/test/src/concrete/oracle/PythOracle.t.sol
@@ -4,6 +4,7 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std/Test.sol";
 import {PythOracle, PythOracleConfig, NonPositivePrice} from "src/concrete/oracle/PythOracle.sol";
+import {IPythOracleV2} from "src/interface/IPythOracleV2.sol";
 import {IPyth} from "pyth-sdk/IPyth.sol";
 import {PythStructs} from "pyth-sdk/PythStructs.sol";
 
@@ -84,8 +85,9 @@ contract PythOracleTest is Test {
     /// Construction emits event and sets immutables.
     function testConstruction() external {
         PythOracle oracle = buildOracle();
-        assertEq(oracle.iPriceFeedId(), FEED_ID);
-        assertEq(oracle.iStaleAfter(), STALE_AFTER);
-        assertEq(address(oracle.iPythContract()), MOCK_PYTH);
+        IPythOracleV2 iOracle = IPythOracleV2(address(oracle));
+        assertEq(iOracle.iPriceFeedId(), FEED_ID);
+        assertEq(iOracle.iStaleAfter(), STALE_AFTER);
+        assertEq(address(iOracle.iPythContract()), MOCK_PYTH);
     }
 }


### PR DESCRIPTION
## Summary
- Add V1 interfaces with original `I_` getter names matching deployed on-chain ABIs
- Add V2 interfaces with new camelCase `i` getter names for new deployments
- Covers: OARV beacon set deployer, ERC20 clone deployer, PythOracle, FtsoV2LTSFeedOracle

Downstream consumers (st0x.deploy) need V1 interfaces for fork tests against existing deployments and V2 for new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new contract interfaces enabling deployment and configuration of receipt vaults and oracle systems with support for multiple implementation versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->