### PR TITLE
make _initialize virtual on authorizer

### DIFF
--- a/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.sol
+++ b/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.sol
@@ -64,7 +64,7 @@ contract OffchainAssetReceiptVaultAuthorizerV1 is IAuthorizeV1, ICloneableV2, Ac
     /// Initialization logic without the initializer modifier so inheriting
     /// contracts can access it and be the initializer. Accepts the decoded
     /// config so child contracts don't need to double-decode.
-    function _initialize(OffchainAssetReceiptVaultAuthorizerV1Config memory config) internal returns (bytes32) {
+    function _initialize(OffchainAssetReceiptVaultAuthorizerV1Config memory config) internal virtual returns (bytes32) {
         __AccessControl_init();
 
         // The config admin MUST be set.


### PR DESCRIPTION
## Summary
- Makes `_initialize` virtual on `OffchainAssetReceiptVaultAuthorizerV1` so child contracts can override it for testing

## Test plan
- Existing tests pass unchanged
- Enables st0x.deploy to test the early return guard in `StoxOffchainAssetReceiptVaultAuthorizerV1.initialize`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced contract extensibility to support derived implementations with customizable initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->