### PR TITLE
make fallback and receive virtual on ReceiptVault

### DIFF
--- a/src/abstract/ReceiptVault.sol
+++ b/src/abstract/ReceiptVault.sol
@@ -128,10 +128,10 @@ abstract contract ReceiptVault is
     }
 
     /// Deposits are payable so this allows refunds.
-    fallback() external payable {}
+    fallback() external payable virtual {}
 
     /// Deposits are payable so this allows refunds.
-    receive() external payable {}
+    receive() external payable virtual {}
 
     /// Initialize the `ReceiptVault`.
     /// @param config All config required for initialization.


### PR DESCRIPTION
## Motivation

Downstream consumers of `ReceiptVault` need to override `fallback()` to route
arbitrary selectors to a diamond facet via `delegatecall`. The current base
declarations are `external payable {}` but not `virtual`, so any subclass that
tries to override either function gets a compiler error.

This lands in `st0x.deploy`'s corporate-actions stack (S01-Issuer/st0x.deploy#70):
`StoxReceiptVault` extends `OffchainAssetReceiptVault` (→ `ReceiptVault`) and
needs a `fallback()` override that delegatecalls to `StoxCorporateActionsFacet`.
Without this upstream change, the whole diamond-facet design is unbuildable
downstream.

## Solution

Add `virtual` to both `fallback()` and `receive()` in `src/abstract/ReceiptVault.sol`.
No behaviour change for any existing caller — both bodies remain empty and are
still `external payable`. Subclasses that don't override get exactly the same
runtime behaviour. Subclasses that do override now compile.

## Checks
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

Related: S01-Issuer/st0x.deploy#70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced contract flexibility by making ETH-handling functions explicitly overridable in derived contracts. No changes to existing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->