### PR TITLE
fix: mark ReceiptVault fallback() and receive() as virtual

### DIFF
--- a/src/abstract/PriceOracleV2.sol
+++ b/src/abstract/PriceOracleV2.sol
@@ -17,8 +17,8 @@ abstract contract PriceOracleV2 is IPriceOracleV2 {
     }
 
     /// Need to accept refunds from the oracle.
-    fallback() external payable {}
+    fallback() external payable virtual {}
 
     /// Need to accept refunds from the oracle.
-    receive() external payable {}
+    receive() external payable virtual {}
 }

--- a/src/abstract/ReceiptVault.sol
+++ b/src/abstract/ReceiptVault.sol
@@ -128,10 +128,10 @@ abstract contract ReceiptVault is
     }
 
     /// Deposits are payable so this allows refunds.
-    fallback() external payable {}
+    fallback() external payable virtual {}
 
     /// Deposits are payable so this allows refunds.
-    receive() external payable {}
+    receive() external payable virtual {}
 
     /// Initialize the `ReceiptVault`.
     /// @param config All config required for initialization.

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.authorize.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.authorize.t.sol
@@ -42,6 +42,12 @@ contract OffchainAssetReceiptVaultAuthorizerV1AuthorizeTest is OffchainAssetRece
         // The sender must not be the admin, otherwise they may hold roles
         // that make the authorize call succeed instead of reverting.
         vm.assume(sender != initialAdmin);
+        // The user must not be the admin either — `authorize` returns early
+        // when `hasRole(permission, user)` is true, and the admin holds
+        // every *_ADMIN role granted in `initialize`. With user == admin
+        // and a permission matching one of those admin roles, the call
+        // succeeds even though the sender has no role.
+        vm.assume(user != initialAdmin);
         OffchainAssetReceiptVaultAuthorizerV1 authorizer = newAuthorizer(initialAdmin);
 
         checkDefaultOffchainAssetReceiptVaultAuthorizerV1AuthorizeUnauthorized(

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.authorize.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.authorize.t.sol
@@ -92,6 +92,12 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1IERC165Test is Offchain
         vm.assume(uint160(paymentToken) > type(uint160).max / 2);
         vm.assume(maxSharesSupply > 0);
         vm.assume(uint160(sender) > type(uint160).max / 2);
+        // The first check in `authorize` only reverts when sender is NOT the
+        // receipt vault. With sender == receiptVault the call falls into the
+        // DEPOSIT / TRANSFER_* branches; an empty `data` then trips
+        // `abi.decode` and reverts without the Unauthorized error selector,
+        // which fails the test's `expectRevert(Unauthorized.selector)`.
+        vm.assume(sender != receiptVault);
         checkDefaultOffchainAssetReceiptVaultAuthorizerV1AuthorizeUnauthorized(
             newAuthorizer(receiptVault, owner, paymentToken, paymentTokenDecimals, maxSharesSupply),
             sender,


### PR DESCRIPTION
Closes #290.

Marks the payable fallback and receive on ReceiptVault as virtual so subclasses can override them. Enables diamond-facet routing patterns like the one st0x.deploy PR #76 wires into StoxReceiptVault.

Behavior unchanged for direct uses of ReceiptVault.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Contract Ether-receiving hooks made extensible to allow safe overrides by future implementations while preserving existing behavior.

* **Tests**
  * Authorization test tightened to exclude admin-edge cases, preventing false positives and ensuring unauthorized paths are properly validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->