### PR TITLE
feat: IAuthorizableV1 interface for OffchainAssetReceiptVault.authorizer()

### DIFF
--- a/src/concrete/vault/OffchainAssetReceiptVault.sol
+++ b/src/concrete/vault/OffchainAssetReceiptVault.sol
@@ -11,6 +11,7 @@ import {
 } from "../../abstract/ReceiptVault.sol";
 import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 import {IAuthorizeV1, Unauthorized} from "../../interface/IAuthorizeV1.sol";
+import {IAuthorizableV1} from "../../interface/IAuthorizableV1.sol";
 import {IERC165} from "openzeppelin-contracts/contracts/utils/introspection/IERC165.sol";
 
 import {ZeroInitialAdmin} from "../authorize/OffchainAssetReceiptVaultAuthorizerV1.sol";
@@ -229,7 +230,7 @@ bytes32 constant WITHDRAW = keccak256("WITHDRAW");
 /// - `ERC20` shares in the vault that can be traded minted/burned to track a peg
 /// - `ERC4626` inspired vault interface (inherited from `ReceiptVault`)
 /// - Fine grained standard Open Zeppelin access control for all system roles
-contract OffchainAssetReceiptVault is IAuthorizeV1, ReceiptVault, OwnerFreezable {
+contract OffchainAssetReceiptVault is IAuthorizableV1, IAuthorizeV1, ReceiptVault, OwnerFreezable {
     using Math for uint256;
 
     /// Contract has initialized.
@@ -337,8 +338,8 @@ contract OffchainAssetReceiptVault is IAuthorizeV1, ReceiptVault, OwnerFreezable
         return interfaceId == type(IAuthorizeV1).interfaceId || super.supportsInterface(interfaceId);
     }
 
-    /// Returns the current authorizer contract.
-    function authorizer() external view returns (IAuthorizeV1) {
+    /// @inheritdoc IAuthorizableV1
+    function authorizer() external view override returns (IAuthorizeV1) {
         OffchainAssetReceiptVault7201Storage storage s = getStorageOffchainAssetReceiptVault();
         return s.authorizer;
     }

--- a/src/interface/IAuthorizableV1.sol
+++ b/src/interface/IAuthorizableV1.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.25;
+
+import {IAuthorizeV1} from "./IAuthorizeV1.sol";
+
+/// @title IAuthorizableV1
+/// @notice Read-only interface for any contract that delegates its
+/// permission checks to an `IAuthorizeV1` contract and exposes the
+/// current authorizer through a getter. The consumer side of the
+/// `IAuthorizeV1` pattern; useful for off-chain tooling, integrators,
+/// and tests that need to identify or pin a contract's current
+/// authorizer without importing the concrete implementation.
+interface IAuthorizableV1 {
+    /// @return The current `IAuthorizeV1` authorizer.
+    function authorizer() external view returns (IAuthorizeV1);
+}


### PR DESCRIPTION
## Summary
Adds `src/interface/IAuthorizableV1.sol` — a minimal read-only interface exposing the `authorizer()` getter on contracts that delegate permission checks to an `IAuthorizeV1`. `OffchainAssetReceiptVault` already had the getter; it now inherits the interface so downstream consumers can read the current authorizer through a typed import without depending on the concrete vault contract.

The vault keeps its existing `is IAuthorizeV1` inheritance. That's a quirk of the bootstrap path: the vault initializes pointing at itself as a revert-always authorizer until the owner calls `setAuthorizer` with a real one. `IAuthorizableV1` is the canonical consumer-side role; `IAuthorizeV1` stays as the parking-spot type for `address(this)` until that bootstrap is rethought (separate concern).

Closes #292.

## Test plan
- [x] `forge build` clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standard interface enabling external systems and off-chain tooling to query the active permission authorizer from vault contracts.

* **Refactor**
  * Updated vault contract to implement the new authorizer interface, enhancing compatibility with integrations and testing frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->