### PR TITLE
feat: ICertifiableV1 interface for OffchainAssetReceiptVault.isCertificationExpired()

### DIFF
--- a/src/concrete/vault/OffchainAssetReceiptVault.sol
+++ b/src/concrete/vault/OffchainAssetReceiptVault.sol
@@ -12,6 +12,7 @@ import {
 import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 import {IAuthorizeV1, Unauthorized} from "../../interface/IAuthorizeV1.sol";
 import {IAuthorizableV1} from "../../interface/IAuthorizableV1.sol";
+import {ICertifiableV1} from "../../interface/ICertifiableV1.sol";
 import {IERC165} from "openzeppelin-contracts/contracts/utils/introspection/IERC165.sol";
 
 import {ZeroInitialAdmin} from "../authorize/OffchainAssetReceiptVaultAuthorizerV1.sol";
@@ -230,7 +231,7 @@ bytes32 constant WITHDRAW = keccak256("WITHDRAW");
 /// - `ERC20` shares in the vault that can be traded minted/burned to track a peg
 /// - `ERC4626` inspired vault interface (inherited from `ReceiptVault`)
 /// - Fine grained standard Open Zeppelin access control for all system roles
-contract OffchainAssetReceiptVault is IAuthorizableV1, IAuthorizeV1, ReceiptVault, OwnerFreezable {
+contract OffchainAssetReceiptVault is IAuthorizableV1, ICertifiableV1, IAuthorizeV1, ReceiptVault, OwnerFreezable {
     using Math for uint256;
 
     /// Contract has initialized.
@@ -604,7 +605,8 @@ contract OffchainAssetReceiptVault is IAuthorizableV1, IAuthorizeV1, ReceiptVaul
         s.authorizer.authorize(_msgSender(), CERTIFY, abi.encode(certifyStateChange));
     }
 
-    function isCertificationExpired() public view returns (bool) {
+    /// @inheritdoc ICertifiableV1
+    function isCertificationExpired() public view override returns (bool) {
         OffchainAssetReceiptVault7201Storage storage s = getStorageOffchainAssetReceiptVault();
         return block.timestamp > s.certifiedUntil;
     }

--- a/src/interface/ICertifiableV1.sol
+++ b/src/interface/ICertifiableV1.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.25;
+
+/// @title ICertifiableV1
+/// @notice Read-only interface for any contract whose operation is gated
+/// on a `certifiedUntil` timestamp set by an offchain certifier and
+/// expiring without renewal. The consumer side: useful for off-chain
+/// tooling, integrators, and tests that need to assert a contract is
+/// currently within its certification window without importing the
+/// concrete implementation.
+interface ICertifiableV1 {
+    /// @return True when the current block timestamp is past the
+    /// contract's `certifiedUntil` time.
+    function isCertificationExpired() external view returns (bool);
+}


### PR DESCRIPTION
## Summary
Adds `src/interface/ICertifiableV1.sol` — a minimal read-only interface exposing the `isCertificationExpired()` getter on contracts gated by a certifier-set expiry timestamp. `OffchainAssetReceiptVault` already had the getter; it now inherits the interface so downstream consumers can read certification state through a typed import without depending on the concrete vault contract.

Mirrors the IAuthorizableV1 pattern from #293.

Closes #294.

## Test plan
- [x] `forge build` clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated vault contract architecture to properly implement certification interface standards, enhancing code organization and improving contract compliance with established interface definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->