### PR TITLE
fix: OwnerFreezable timestamp boundaries inclusive to match certifiedUntil (#296)

### DIFF
--- a/src/abstract/OwnerFreezable.sol
+++ b/src/abstract/OwnerFreezable.sol
@@ -47,17 +47,20 @@ bytes32 constant OWNER_FREEZABLE_V1_STORAGE_LOCATION =
 /// addresses, to mitigate the risk that the attacker opens up the ability to
 /// dump on the LPs en masse after the snapshot.
 abstract contract OwnerFreezable is IOwnerFreezableV1, OwnableUpgradeable {
-    /// @param ownerFrozenUntil Contract is frozen until this time.
+    /// @param ownerFrozenUntil Contract is frozen through and including this
+    /// time. Inclusive boundary — at `block.timestamp == ownerFrozenUntil`
+    /// the contract is still frozen; the freeze releases on the first block
+    /// where `block.timestamp > ownerFrozenUntil`.
     /// @param alwaysAllowedFroms Mapping of `from` addresses that are always
     /// allowed to send. If the protected time is any non-zero value then the
-    /// `from` address is always allowed to send. While the current time is less
-    /// than the protected time the `from` address cannot be removed from the
-    /// always allowed list.
+    /// `from` address is always allowed to send. While the current time is at
+    /// or before the protected time the `from` address cannot be removed from
+    /// the always allowed list (inclusive boundary).
     /// @param alwaysAllowedTos Mapping of `to` addresses that are always
     /// allowed to receive. If the protected time is any non-zero value then the
-    /// `to` address is always allowed to receive. While the current time is less
-    /// than the protected time the `to` address cannot be removed from the
-    /// always allowed list.
+    /// `to` address is always allowed to receive. While the current time is at
+    /// or before the protected time the `to` address cannot be removed from the
+    /// always allowed list (inclusive boundary).
     /// @custom:storage-location erc7201:rain.storage.owner-freezable.1
     struct OwnerFreezableV17201Storage {
         uint256 ownerFrozenUntil;
@@ -137,9 +140,12 @@ abstract contract OwnerFreezable is IOwnerFreezableV1, OwnableUpgradeable {
     function ownerFreezeStopAlwaysAllowingFrom(address from) external onlyOwner {
         OwnerFreezableV17201Storage storage s = getStorageOwnerFreezable();
 
-        // If the current time is after the protection for this `from` then
-        // we can remove it. Otherwise we revert to respect the protection.
-        if (block.timestamp < s.alwaysAllowedFroms[from]) {
+        // Inclusive boundary: protection is active through and including
+        // `protectedUntil`. Removal becomes possible only once
+        // `block.timestamp > protectedUntil`. Matches the convention used
+        // by `OffchainAssetReceiptVault.certifiedUntil` and the corporate
+        // action `effectiveTime` semantics on consumers.
+        if (block.timestamp <= s.alwaysAllowedFroms[from]) {
             revert OwnerFreezeAlwaysAllowedFromProtected(from, s.alwaysAllowedFroms[from]);
         }
 
@@ -173,9 +179,8 @@ abstract contract OwnerFreezable is IOwnerFreezableV1, OwnableUpgradeable {
     function ownerFreezeStopAlwaysAllowingTo(address to) external onlyOwner {
         OwnerFreezableV17201Storage storage s = getStorageOwnerFreezable();
 
-        // If the current time is after the protection for this `to` then
-        // we can remove it. Otherwise we revert to respect the protection.
-        if (block.timestamp < s.alwaysAllowedTos[to]) {
+        // Inclusive boundary — see `ownerFreezeStopAlwaysAllowingFrom`.
+        if (block.timestamp <= s.alwaysAllowedTos[to]) {
             revert IOwnerFreezableV1.OwnerFreezeAlwaysAllowedToProtected(to, s.alwaysAllowedTos[to]);
         }
 
@@ -193,7 +198,10 @@ abstract contract OwnerFreezable is IOwnerFreezableV1, OwnableUpgradeable {
         // We either simply revert or no-op for this check.
         // Revert if the contract is frozen and neither the `from` nor `to` are
         // in their respective always allowed lists.
-        if (block.timestamp < s.ownerFrozenUntil && s.alwaysAllowedFroms[from] == 0 && s.alwaysAllowedTos[to] == 0) {
+        // Inclusive boundary: the freeze is active through and including
+        // `ownerFrozenUntil`. Matches the convention used by
+        // `OffchainAssetReceiptVault.certifiedUntil`.
+        if (block.timestamp <= s.ownerFrozenUntil && s.alwaysAllowedFroms[from] == 0 && s.alwaysAllowedTos[to] == 0) {
             revert IOwnerFreezableV1.OwnerFrozen(s.ownerFrozenUntil, from, to);
         }
     }

--- a/src/abstract/OwnerFreezable.sol
+++ b/src/abstract/OwnerFreezable.sol
@@ -8,6 +8,19 @@ import {IOwnerFreezableV1, IERC5313} from "../interface/IOwnerFreezableV1.sol";
 /// @dev String ID for the OwnerFreezableV1 storage location v1.
 string constant OWNER_FREEZABLE_V1_STORAGE_ID = "rain.storage.owner-freezable.1";
 
+/// @dev Thrown when an inheritor's initializer runs at `block.timestamp ==
+/// 0`. This indicates a corrupted execution environment, not a user
+/// input error: every real EVM has a non-zero block timestamp from
+/// genesis onward (decades in the past), so a zero timestamp can only
+/// arise under contrived test setups (`vm.warp(0)`) or a malformed
+/// fork. `OwnerFreezable`'s inclusive timestamp checks treat the
+/// stored 0 sentinel as an active deadline at the genesis timestamp,
+/// so allowing initialization through this state would let the
+/// inheritor wedge itself in an ambiguous freeze permanently.
+/// Refuse the deployment at the boundary instead of carrying the
+/// ambiguity forward.
+error CorruptedEnvironmentBlockTimestampZero();
+
 /// @dev "rain.storage.owner-freezable.1" with the erc7201 formula.
 bytes32 constant OWNER_FREEZABLE_V1_STORAGE_LOCATION =
     0x04485615b1da6633eec3daf54aadca2a89ef8b155744e223a046f4a6e38be700;
@@ -73,6 +86,13 @@ abstract contract OwnerFreezable is IOwnerFreezableV1, OwnableUpgradeable {
         assembly ("memory-safe") {
             s.slot := OWNER_FREEZABLE_V1_STORAGE_LOCATION
         }
+    }
+
+    /// @dev Init-time guard against the `block.timestamp == 0` corner.
+    /// Inheritors MUST call this from their initializer.
+    // slither-disable-next-line dead-code
+    function __OwnerFreezable_init() internal {
+        if (block.timestamp == 0) revert CorruptedEnvironmentBlockTimestampZero();
     }
 
     /// @inheritdoc IERC5313

--- a/src/abstract/OwnerFreezable.sol
+++ b/src/abstract/OwnerFreezable.sol
@@ -90,7 +90,17 @@ abstract contract OwnerFreezable is IOwnerFreezableV1, OwnableUpgradeable {
 
     /// @dev Init-time guard against the `block.timestamp == 0` corner.
     /// Inheritors MUST call this from their initializer.
-    // slither-disable-next-line dead-code
+    /// slither-disable-next-line is documented per rule:
+    /// - dead-code: function is internal and called by every inheritor's
+    ///   own initializer; slither doesn't see the inheritance graph here.
+    /// - naming-convention: matches OpenZeppelin Upgradeable's
+    ///   `__Foo_init` convention for initializer fragments rather than
+    ///   the standard mixedCase rule.
+    /// - incorrect-equality: the `== 0` check is the entire point —
+    ///   detecting the genesis sentinel state. Inequality comparisons
+    ///   would either let in negative inputs (impossible for uint) or
+    ///   miss the exact zero we need to reject.
+    // slither-disable-next-line dead-code,naming-convention,incorrect-equality
     function __OwnerFreezable_init() internal {
         if (block.timestamp == 0) revert CorruptedEnvironmentBlockTimestampZero();
     }

--- a/src/concrete/vault/OffchainAssetReceiptVault.sol
+++ b/src/concrete/vault/OffchainAssetReceiptVault.sol
@@ -301,6 +301,8 @@ contract OffchainAssetReceiptVault is IAuthorizableV1, ICertifiableV1, IAuthoriz
     /// logic.
     /// @param data All config required to initialize abi encoded.
     function initialize(bytes memory data) public virtual override initializer returns (bytes32) {
+        __OwnerFreezable_init();
+
         OffchainAssetReceiptVaultConfigV2 memory config = abi.decode(data, (OffchainAssetReceiptVaultConfigV2));
 
         __ReceiptVault_init(config.receiptVaultConfig);

--- a/test/abstract/OwnerFreezableOwnerFreezeUntilTest.sol
+++ b/test/abstract/OwnerFreezableOwnerFreezeUntilTest.sol
@@ -335,4 +335,72 @@ abstract contract OwnerFreezableOwnerFreezeUntilTest is OffchainAssetReceiptVaul
         );
         sOwnerFreezable.ownerFreezeStopAlwaysAllowingTo(to);
     }
+
+    /// Inclusive boundary: at exactly `block.timestamp == protectUntil` the
+    /// `from`-side protection is still active. A regression flipping the
+    /// `<=` back to `<` would silently pass the existing pre-boundary-only
+    /// fuzz (which only deterministically covers `< protectUntil`).
+    function testOwnerFreezableAlwaysAllowFromProtectedRevertsAtExactBoundary(address from, uint256 protectUntil)
+        external
+    {
+        vm.assume(from != address(0));
+        protectUntil = bound(protectUntil, 1, type(uint256).max);
+        checkOwnerFreezeAlwaysAllowFrom(from, protectUntil, protectUntil);
+
+        vm.warp(protectUntil);
+        vm.prank(sAlice);
+        vm.expectRevert(
+            abi.encodeWithSelector(IOwnerFreezableV1.OwnerFreezeAlwaysAllowedFromProtected.selector, from, protectUntil)
+        );
+        sOwnerFreezable.ownerFreezeStopAlwaysAllowingFrom(from);
+    }
+
+    /// Inclusive boundary: at exactly `block.timestamp == protectUntil` the
+    /// `to`-side protection is still active. Mirror of the `from` boundary
+    /// pin above.
+    function testOwnerFreezableAlwaysAllowToProtectedRevertsAtExactBoundary(address to, uint256 protectUntil) external {
+        vm.assume(to != address(0));
+        protectUntil = bound(protectUntil, 1, type(uint256).max);
+        checkOwnerFreezeAlwaysAllowTo(to, protectUntil, protectUntil);
+
+        vm.warp(protectUntil);
+        vm.prank(sAlice);
+        vm.expectRevert(
+            abi.encodeWithSelector(IOwnerFreezableV1.OwnerFreezeAlwaysAllowedToProtected.selector, to, protectUntil)
+        );
+        sOwnerFreezable.ownerFreezeStopAlwaysAllowingTo(to);
+    }
+
+    /// Inclusive boundary: at exactly `block.timestamp == protectUntil + 1`
+    /// the protection releases and removal succeeds. Pinned alongside the
+    /// boundary-revert tests so a regression that shifted the inclusivity
+    /// in either direction trips one of the two.
+    function testOwnerFreezableAlwaysAllowFromRemovableJustPastBoundary(address from, uint256 protectUntil) external {
+        vm.assume(from != address(0));
+        protectUntil = bound(protectUntil, 1, type(uint256).max - 1);
+        checkOwnerFreezeAlwaysAllowFrom(from, protectUntil, protectUntil);
+
+        vm.warp(protectUntil + 1);
+        vm.prank(sAlice);
+        vm.expectEmit(true, true, true, true);
+        emit IOwnerFreezableV1.OwnerFreezeAlwaysAllowedFrom(sAlice, from, 0, 0);
+        sOwnerFreezable.ownerFreezeStopAlwaysAllowingFrom(from);
+        assertEq(sOwnerFreezable.ownerFreezeAlwaysAllowedFrom(from), 0);
+    }
+
+    /// Inclusive boundary: at exactly `block.timestamp == protectUntil + 1`
+    /// the `to`-side protection releases. Mirror of the `from` post-boundary
+    /// pin above.
+    function testOwnerFreezableAlwaysAllowToRemovableJustPastBoundary(address to, uint256 protectUntil) external {
+        vm.assume(to != address(0));
+        protectUntil = bound(protectUntil, 1, type(uint256).max - 1);
+        checkOwnerFreezeAlwaysAllowTo(to, protectUntil, protectUntil);
+
+        vm.warp(protectUntil + 1);
+        vm.prank(sAlice);
+        vm.expectEmit(true, true, true, true);
+        emit IOwnerFreezableV1.OwnerFreezeAlwaysAllowedTo(sAlice, to, 0, 0);
+        sOwnerFreezable.ownerFreezeStopAlwaysAllowingTo(to);
+        assertEq(sOwnerFreezable.ownerFreezeAlwaysAllowedTo(to), 0);
+    }
 }

--- a/test/abstract/OwnerFreezableOwnerFreezeUntilTest.sol
+++ b/test/abstract/OwnerFreezableOwnerFreezeUntilTest.sol
@@ -33,9 +33,14 @@ abstract contract OwnerFreezableOwnerFreezeUntilTest is OffchainAssetReceiptVaul
     }
 
     function checkOwnerFreezeStopAlwaysAllowingFrom(address from) internal {
-        uint256 time = sOwnerFreezable.ownerFreezeAlwaysAllowedFrom(from);
-        time = bound(time, time, type(uint256).max);
-        vm.warp(time);
+        uint256 protectedUntil = sOwnerFreezable.ownerFreezeAlwaysAllowedFrom(from);
+        // Inclusive boundary: protection is active through and including
+        // `protectedUntil`. Removal is only possible at `block.timestamp >
+        // protectedUntil`. If `protectedUntil == type(uint256).max`, the
+        // protection is permanent (no later block exists) so this helper
+        // can't exercise the removal — skip via `vm.assume`.
+        vm.assume(protectedUntil < type(uint256).max);
+        vm.warp(protectedUntil + 1);
         vm.prank(sAlice);
         vm.expectEmit(true, true, true, true);
         emit IOwnerFreezableV1.OwnerFreezeAlwaysAllowedFrom(sAlice, from, 0, 0);
@@ -52,9 +57,10 @@ abstract contract OwnerFreezableOwnerFreezeUntilTest is OffchainAssetReceiptVaul
     }
 
     function checkOwnerFreezeStopAlwaysAllowingTo(address to) internal {
-        uint256 time = sOwnerFreezable.ownerFreezeAlwaysAllowedTo(to);
-        time = bound(time, time, type(uint256).max);
-        vm.warp(time);
+        uint256 protectedUntil = sOwnerFreezable.ownerFreezeAlwaysAllowedTo(to);
+        // Inclusive boundary — see `checkOwnerFreezeStopAlwaysAllowingFrom`.
+        vm.assume(protectedUntil < type(uint256).max);
+        vm.warp(protectedUntil + 1);
         vm.prank(sAlice);
         vm.expectEmit(true, true, true, true);
         emit IOwnerFreezableV1.OwnerFreezeAlwaysAllowedTo(sAlice, to, 0, 0);
@@ -206,13 +212,15 @@ abstract contract OwnerFreezableOwnerFreezeUntilTest is OffchainAssetReceiptVaul
         checkOwnerFreezeStopAlwaysAllowingFrom(from2);
     }
 
-    /// Calling ownerFreezeStopAlwaysAllowingFrom before the protected time reverts.
+    /// Inclusive boundary: calling ownerFreezeStopAlwaysAllowingFrom at or
+    /// before the protected time reverts. The boundary case
+    /// (`block.timestamp == protectUntil`) is included in the revert range.
     function testOwnerFreezableAlwaysAllowFromProtectedReverts(address from, uint256 protectUntil, uint256 time)
         external
     {
         vm.assume(from != address(0));
         vm.assume(protectUntil != 0);
-        time = bound(time, 0, protectUntil - 1);
+        time = bound(time, 0, protectUntil);
         checkOwnerFreezeAlwaysAllowFrom(from, protectUntil, protectUntil);
 
         vm.warp(time);
@@ -312,11 +320,13 @@ abstract contract OwnerFreezableOwnerFreezeUntilTest is OffchainAssetReceiptVaul
         checkOwnerFreezeStopAlwaysAllowingTo(to2);
     }
 
-    /// Calling ownerFreezeStopAlwaysAllowingTo before the protected time reverts.
+    /// Inclusive boundary: calling ownerFreezeStopAlwaysAllowingTo at or
+    /// before the protected time reverts. The boundary case
+    /// (`block.timestamp == protectUntil`) is included in the revert range.
     function testOwnerFreezableAlwaysAllowToProtectedReverts(address to, uint256 protectUntil, uint256 time) external {
         vm.assume(to != address(0));
         vm.assume(protectUntil != 0);
-        time = bound(time, 0, protectUntil - 1);
+        time = bound(time, 0, protectUntil);
         checkOwnerFreezeAlwaysAllowTo(to, protectUntil, protectUntil);
         vm.warp(time);
         vm.prank(sAlice);

--- a/test/src/abstract/OwnerFreezable.ownerFreezeUntil.t.sol
+++ b/test/src/abstract/OwnerFreezable.ownerFreezeUntil.t.sol
@@ -7,6 +7,7 @@ import {OwnerFreezable} from "src/abstract/OwnerFreezable.sol";
 
 contract TestOwnerFreezable is OwnerFreezable {
     constructor() {
+        __OwnerFreezable_init();
         _transferOwnership(msg.sender);
     }
 }

--- a/test/src/concrete/vault/OffchainAssetReceiptVault.initialize.t.sol
+++ b/test/src/concrete/vault/OffchainAssetReceiptVault.initialize.t.sol
@@ -9,11 +9,41 @@ import {
     ZeroInitialAdmin,
     NonZeroAsset
 } from "src/concrete/vault/OffchainAssetReceiptVault.sol";
+import {CorruptedEnvironmentBlockTimestampZero} from "src/abstract/OwnerFreezable.sol";
 import {Receipt as ReceiptContract} from "src/concrete/receipt/Receipt.sol";
 import {BeaconProxy} from "openzeppelin-contracts/contracts/proxy/beacon/BeaconProxy.sol";
 import {LibUniqueAddressesGenerator} from "../../../lib/LibUniqueAddressesGenerator.sol";
 
 contract OffChainAssetReceiptVaultInitializeTest is OffchainAssetReceiptVaultTest {
+    /// Inclusive timestamp comparisons in `OwnerFreezable` treat the
+    /// stored 0 sentinel as an active deadline at `block.timestamp == 0`.
+    /// Production timestamps are never 0 (genesis is decades past) so
+    /// the ambiguous state is unreachable in real execution. The
+    /// `__OwnerFreezable_init` guard pins this contractually:
+    /// `initialize` reverts with `CorruptedEnvironmentBlockTimestampZero` if
+    /// somehow called at `block.timestamp == 0`, so no inheritor lands
+    /// in the ambiguous state even under contrived test setups.
+    function testInitAtGenesisTimestampReverts(string memory shareName, string memory shareSymbol) external {
+        ReceiptContract receipt = ReceiptContract(address(new BeaconProxy(address(iDeployer.iReceiptBeacon()), "")));
+        OffchainAssetReceiptVault offchainAssetReceiptVault = OffchainAssetReceiptVault(
+            payable(address(new BeaconProxy(address(iDeployer.iOffchainAssetReceiptVaultBeacon()), "")))
+        );
+        receipt.initialize(abi.encode(offchainAssetReceiptVault));
+
+        vm.warp(0);
+        vm.expectRevert(CorruptedEnvironmentBlockTimestampZero.selector);
+        offchainAssetReceiptVault.initialize(
+            abi.encode(
+                OffchainAssetReceiptVaultConfigV2({
+                    initialAdmin: address(1),
+                    receiptVaultConfig: ReceiptVaultConfigV2({
+                        asset: address(0), name: shareName, symbol: shareSymbol, receipt: address(receipt)
+                    })
+                })
+            )
+        );
+    }
+
     /// Test that admin is not address zero
     function testZeroInitialAdmin(string memory shareName, string memory shareSymbol) external {
         ReceiptContract receipt = ReceiptContract(address(new BeaconProxy(address(iDeployer.iReceiptBeacon()), "")));

--- a/test/src/concrete/vault/OffchainAssetReceiptVault.ownerFreezeUntil.t.sol
+++ b/test/src/concrete/vault/OffchainAssetReceiptVault.ownerFreezeUntil.t.sol
@@ -30,7 +30,13 @@ contract OffchainAssetReceiptVaultOwnerFreezeUntilTest is OwnerFreezableOwnerFre
         vm.startPrank(sAlice);
         OffchainAssetReceiptVault vault = OffchainAssetReceiptVault(payable(address(sOwnerFreezable)));
         IAccessControl(address(vault.authorizer())).grantRole(CERTIFY, sAlice);
-        vault.certify(block.timestamp + 1, false, "");
+        // Certify well past any freeze deadline used in these tests. The
+        // freeze tests warp past `frozenUntil` to verify the freeze
+        // releases; with inclusive freeze semantics that warp lands at
+        // `frozenUntil + 1`, which would also expire a certification set
+        // to `block.timestamp + 1`. Set certification far enough out that
+        // it stays valid across every warp the tests perform.
+        vault.certify(type(uint128).max, false, "");
 
         IAccessControl(address(vault.authorizer())).grantRole(DEPOSIT, sAlice);
         vault.deposit(1e18, sBob, 0, "");
@@ -54,7 +60,9 @@ contract OffchainAssetReceiptVaultOwnerFreezeUntilTest is OwnerFreezableOwnerFre
         } else {
             console2.log("Giving reason to transfer from:", from, "to:", to);
             uint256 frozenUntil = vault.ownerFrozenUntil();
-            vm.warp(frozenUntil);
+            // Inclusive boundary: freeze releases at the first block where
+            // `block.timestamp > frozenUntil`. Warp past the deadline.
+            vm.warp(frozenUntil + 1);
         }
     }
 

--- a/test/src/concrete/vault/OffchainAssetReceiptVault.ownerFreezeUntil.t.sol
+++ b/test/src/concrete/vault/OffchainAssetReceiptVault.ownerFreezeUntil.t.sol
@@ -73,6 +73,42 @@ contract OffchainAssetReceiptVaultOwnerFreezeUntilTest is OwnerFreezableOwnerFre
         assertTrue(vault.transfer(sAlice, 1e18));
     }
 
+    /// Inclusive boundary: at exactly `block.timestamp == ownerFrozenUntil`
+    /// the freeze is still active and transfers revert with `OwnerFrozen`.
+    /// `testTokenTransferFroze` only covers `freezeUntil - 1` (strictly
+    /// before); without this boundary pin, a regression flipping the
+    /// `<=` back to `<` in `ownerFreezeCheckTransaction` would silently
+    /// pass the existing tests while breaking the inclusive contract.
+    function testTokenTransferFrozenAtExactBoundaryReverts() external {
+        OffchainAssetReceiptVault vault = setupTokenTransferTest();
+
+        uint256 freezeUntil = block.timestamp + 1;
+        vm.prank(sAlice);
+        vault.ownerFreezeUntil(freezeUntil);
+
+        vm.warp(freezeUntil);
+        vm.prank(sBob);
+        vm.expectRevert(abi.encodeWithSelector(IOwnerFreezableV1.OwnerFrozen.selector, freezeUntil, sBob, sAlice));
+        assertFalse(vault.transfer(sAlice, 1e18));
+    }
+
+    /// Inclusive boundary, post-release side: at exactly `block.timestamp
+    /// == ownerFrozenUntil + 1` the freeze releases and a transfer with
+    /// no allow-list entries succeeds. Pinned alongside the boundary-
+    /// revert test so a regression that shifted the inclusivity in either
+    /// direction trips one of the two.
+    function testTokenTransferUnfrozenJustAfterBoundary() external {
+        OffchainAssetReceiptVault vault = setupTokenTransferTest();
+
+        uint256 freezeUntil = block.timestamp + 1;
+        vm.prank(sAlice);
+        vault.ownerFreezeUntil(freezeUntil);
+
+        vm.warp(freezeUntil + 1);
+        vm.prank(sBob);
+        assertTrue(vault.transfer(sAlice, 1e18));
+    }
+
     function testTokenTransferFroze(uint256 seed) external {
         OffchainAssetReceiptVault vault = setupTokenTransferTest();
 


### PR DESCRIPTION
Fixes #296.

Switch the three `OwnerFreezable` boundary comparisons from `<` to `<=` so the package is internally consistent with `OffchainAssetReceiptVault.certifiedUntil` (also inclusive). Without this, consumers mixing the two on the same timestamp see asymmetric behaviour at the exact boundary block — the freeze releases while certification is still valid (or vice versa, depending on which they pin to).

## Source changes

- `ownerFreezeStopAlwaysAllowingFrom` / `ownerFreezeStopAlwaysAllowingTo`: protection active through and including `protectedUntil`; removable only at `block.timestamp > protectedUntil`.
- `ownerFreezeCheckTransaction`: freeze active through and including `ownerFrozenUntil`.
- Storage field NatSpec updated to describe the inclusive semantics directly.

## Test updates

- `checkOwnerFreezeStopAllowing*` helpers warp to `protectedUntil + 1`, with `vm.assume(protectedUntil < type(uint256).max)` because permanent protection (deadline at max uint256) has no later block to remove from.
- `testOwnerFreezable*ProtectedReverts` bound the revert range to `[0, protectUntil]` inclusive.
- `giveReasonToTransfer` (vault test) warps to `frozenUntil + 1`.
- `setupTokenTransferTest` certifies to `type(uint128).max` so certification outlasts the freeze warp (was `block.timestamp + 1` which now expires at the same warp under inclusive semantics).

## Test plan
- [x] full suite passes (329/329)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined owner freeze/protection boundary conditions to use inclusive timestamp semantics. Restrictions now apply through the exact `block.timestamp` boundary rather than stopping immediately before it.

* **Tests**
  * Added comprehensive boundary-pinning tests to verify correct behavior at exact freeze/protection timeout transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->