### PR TITLE
fix: surface oracle reverts from ERC20PriceOracleReceiptVault._nextId

### DIFF
--- a/src/concrete/vault/ERC20PriceOracleReceiptVault.sol
+++ b/src/concrete/vault/ERC20PriceOracleReceiptVault.sol
@@ -124,25 +124,21 @@ contract ERC20PriceOracleReceiptVault is ReceiptVault {
     function _nextId() internal virtual override returns (uint256) {
         ERC20PriceOracleReceiptVault7201Storage storage s = getStorageERC20PriceOracleReceiptVault();
 
-        // The oracle CAN error so we wrap in a try block to meet spec
-        // requirement that calls MUST NOT revert.
-        // This contract is never intended to hold gas, it's only here to pay the
-        // oracles that might need to be paid. The contract's assets are always
-        // ERC20 tokens. This means the slither detector here is a false positive.
+        // Oracle reverts propagate. Catching them here collapses every oracle
+        // error into a downstream `Panic(0x12)` from divide-by-zero in
+        // `_calculate{Deposit,Mint}`, hiding the actual selector (e.g. Pyth
+        // `StalePrice()`) from integrators, frontends and on-chain monitoring.
+        // The ERC4626 "MUST NOT revert" requirement applies to the view-only
+        // `max*` functions; `mint`/`deposit` may revert, and `previewMint`/
+        // `previewDeposit` may revert "due to other conditions that would
+        // also cause deposit/mint to revert" — a reverting oracle qualifies.
+        //
+        // This contract is never intended to hold gas, it's only here to pay
+        // the oracles that might need to be paid. The contract's assets are
+        // always ERC20 tokens. This means the slither detector here is a
+        // false positive.
         //slither-disable-next-line arbitrary-send-eth
-        try s.priceOracle.price{value: address(this).balance}()
-        // slither puts false positives on `try/catch/returns`.
-        // https://github.com/crytic/slither/issues/511
-        //slither-disable-next-line
-        returns (
-            uint256 price
-        ) {
-            return price;
-        } catch {
-            // Depositing assets while the price oracle is erroring will give 0
-            // shares (a real deposit will revert due to 0 ratio).
-            return 0;
-        }
+        return s.priceOracle.price{value: address(this).balance}();
     }
 
     /// The ID-less share ratio is the current oracle price, which will be the

--- a/test/src/concrete/vault/ERC20PriceOracleReceiptVault.oracleRevert.t.sol
+++ b/test/src/concrete/vault/ERC20PriceOracleReceiptVault.oracleRevert.t.sol
@@ -53,28 +53,6 @@ contract ERC20PriceOracleReceiptVaultOracleRevertTest is ERC20PriceOracleReceipt
         vault.previewDeposit(assets, 0);
     }
 
-    /// ERC4626 spec: `max*` MUST NOT revert. The fix removes the try/catch
-    /// around `priceOracle.price()` in `_nextId`; pin that none of the `max*`
-    /// view functions route through `_nextId` so a reverting oracle never
-    /// reaches that surface. `id` is bounded `> 0` because `_calculateRedeem`
-    /// divides by share ratio and would panic on `id == 0` — that's a
-    /// separate, oracle-independent invariant outside the scope of this fix.
-    function testMaxFunctionsDoNotRevertOnOracleRevert(
-        string memory name,
-        string memory symbol,
-        address receiver,
-        address owner,
-        uint256 id
-    ) external {
-        id = bound(id, 1, type(uint256).max);
-        ERC20PriceOracleReceiptVault vault = createVault(iVaultOracle, name, symbol);
-        mockOracleRevert();
-        vault.maxDeposit(receiver);
-        vault.maxMint(receiver);
-        vault.maxRedeem(owner, id);
-        vault.maxWithdraw(owner, id);
-    }
-
     receive() external payable {}
 
     fallback() external payable {}

--- a/test/src/concrete/vault/ERC20PriceOracleReceiptVault.oracleRevert.t.sol
+++ b/test/src/concrete/vault/ERC20PriceOracleReceiptVault.oracleRevert.t.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {ERC20PriceOracleReceiptVaultTest} from "test/abstract/ERC20PriceOracleReceiptVaultTest.sol";
+import {ERC20PriceOracleReceiptVault} from "src/concrete/vault/ERC20PriceOracleReceiptVault.sol";
+import {IPriceOracleV2} from "src/interface/IPriceOracleV2.sol";
+
+/// Oracle errors must surface from `_nextId` to the caller of mint / deposit /
+/// previewMint / previewDeposit. The previous behaviour caught any revert and
+/// returned 0, which collapsed downstream into a `Panic(0x12)` divide-by-zero
+/// and erased the underlying selector (e.g. Pyth `StalePrice()`).
+contract ERC20PriceOracleReceiptVaultOracleRevertTest is ERC20PriceOracleReceiptVaultTest {
+    /// Arbitrary custom selector standing in for any oracle-side error
+    /// (e.g. Pyth `StalePrice()` = 0x19abf40e).
+    error OracleError();
+
+    function mockOracleRevert() internal {
+        vm.mockCallRevert(
+            address(iVaultOracle),
+            abi.encodeWithSelector(IPriceOracleV2.price.selector),
+            abi.encodeWithSelector(OracleError.selector)
+        );
+    }
+
+    function testMintPropagatesOracleRevert(string memory name, string memory symbol, uint256 shares) external {
+        ERC20PriceOracleReceiptVault vault = createVault(iVaultOracle, name, symbol);
+        mockOracleRevert();
+        vm.expectRevert(abi.encodeWithSelector(OracleError.selector));
+        vault.mint(shares, address(this), 0, "");
+    }
+
+    function testDepositPropagatesOracleRevert(string memory name, string memory symbol, uint256 assets) external {
+        ERC20PriceOracleReceiptVault vault = createVault(iVaultOracle, name, symbol);
+        mockOracleRevert();
+        vm.expectRevert(abi.encodeWithSelector(OracleError.selector));
+        vault.deposit(assets, address(this), 0, "");
+    }
+
+    function testPreviewMintPropagatesOracleRevert(string memory name, string memory symbol, uint256 shares) external {
+        ERC20PriceOracleReceiptVault vault = createVault(iVaultOracle, name, symbol);
+        mockOracleRevert();
+        vm.expectRevert(abi.encodeWithSelector(OracleError.selector));
+        vault.previewMint(shares, 0);
+    }
+
+    function testPreviewDepositPropagatesOracleRevert(string memory name, string memory symbol, uint256 assets)
+        external
+    {
+        ERC20PriceOracleReceiptVault vault = createVault(iVaultOracle, name, symbol);
+        mockOracleRevert();
+        vm.expectRevert(abi.encodeWithSelector(OracleError.selector));
+        vault.previewDeposit(assets, 0);
+    }
+
+    receive() external payable {}
+
+    fallback() external payable {}
+}

--- a/test/src/concrete/vault/ERC20PriceOracleReceiptVault.oracleRevert.t.sol
+++ b/test/src/concrete/vault/ERC20PriceOracleReceiptVault.oracleRevert.t.sol
@@ -53,6 +53,28 @@ contract ERC20PriceOracleReceiptVaultOracleRevertTest is ERC20PriceOracleReceipt
         vault.previewDeposit(assets, 0);
     }
 
+    /// ERC4626 spec: `max*` MUST NOT revert. The fix removes the try/catch
+    /// around `priceOracle.price()` in `_nextId`; pin that none of the `max*`
+    /// view functions route through `_nextId` so a reverting oracle never
+    /// reaches that surface. `id` is bounded `> 0` because `_calculateRedeem`
+    /// divides by share ratio and would panic on `id == 0` — that's a
+    /// separate, oracle-independent invariant outside the scope of this fix.
+    function testMaxFunctionsDoNotRevertOnOracleRevert(
+        string memory name,
+        string memory symbol,
+        address receiver,
+        address owner,
+        uint256 id
+    ) external {
+        id = bound(id, 1, type(uint256).max);
+        ERC20PriceOracleReceiptVault vault = createVault(iVaultOracle, name, symbol);
+        mockOracleRevert();
+        vault.maxDeposit(receiver);
+        vault.maxMint(receiver);
+        vault.maxRedeem(owner, id);
+        vault.maxWithdraw(owner, id);
+    }
+
     receive() external payable {}
 
     fallback() external payable {}


### PR DESCRIPTION
## Summary
- Drop the bare `try/catch` around `priceOracle.price()` in `_nextId`. The catch returned 0, collapsing every oracle error into a downstream `Panic(0x12)` from divide-by-zero in `_calculateMint`/`_calculateDeposit`, erasing the actual selector (e.g. Pyth `StalePrice()`).
- ERC4626's "MUST NOT revert" surface (`max*`) is unaffected — those functions don't route through `_nextId`. `mint`/`deposit` may revert, and `previewMint`/`previewDeposit` may revert "due to other conditions that would also cause deposit/mint to revert" per spec; a reverting oracle qualifies.
- Independent of this PR, the `max*` surface has its own MUST-NOT-revert gap (`maxWithdraw(owner, 0)` panics) tracked in #303.

Closes #299

## Test plan
- [x] New fuzz tests assert the oracle's custom selector propagates through `mint`, `deposit`, `previewMint`, `previewDeposit`.
- [x] TDD-verified: tests fail against unfixed code with `Panic(0x12)` / `ZeroSharesAmount()`; pass after the fix.
- [x] Full suite green (344/344 non-fork tests pass).
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)