### PR TITLE
fix: maxWithdraw returns 0 instead of reverting on zero share ratio

### DIFF
--- a/src/abstract/ReceiptVault.sol
+++ b/src/abstract/ReceiptVault.sol
@@ -264,14 +264,21 @@ abstract contract ReceiptVault is
 
     /// @inheritdoc IReceiptVaultV1
     function maxWithdraw(address owner, uint256 id) public view virtual returns (uint256) {
+        // Assume the owner is hypothetically withdrawing for themselves.
+        uint256 shareRatio = _shareRatio(owner, owner, id, ShareAction.Burn);
+        // ERC-4626 maxWithdraw MUST NOT revert. Subclasses (e.g.
+        // `ERC20PriceOracleReceiptVault`) return `id` as the share ratio, so
+        // `id == 0` produces a zero share ratio that would divide by zero in
+        // `_calculateRedeem`. A zero share ratio means a withdraw at this id
+        // is undefined / never had a corresponding deposit, so the max
+        // withdrawable is 0.
+        if (shareRatio == 0) {
+            return 0;
+        }
         // Using `_calculateRedeem` instead of `_calculateWithdraw` because the
         // latter requires knowing the assets being withdrawn, which is what we
         // are attempting to reverse engineer from the owner's receipt balance.
-        return _calculateRedeem(
-            receipt().balanceOf(owner, id),
-            // Assume the owner is hypothetically withdrawing for themselves.
-            _shareRatio(owner, owner, id, ShareAction.Burn)
-        );
+        return _calculateRedeem(receipt().balanceOf(owner, id), shareRatio);
     }
 
     /// @inheritdoc IReceiptVaultV1

--- a/src/abstract/ReceiptVault.sol
+++ b/src/abstract/ReceiptVault.sol
@@ -272,6 +272,10 @@ abstract contract ReceiptVault is
         // `_calculateRedeem`. A zero share ratio means a withdraw at this id
         // is undefined / never had a corresponding deposit, so the max
         // withdrawable is 0.
+        //
+        // Strict equality is the correct check here: any nonzero ratio is
+        // safe to divide by, only an exact zero produces the panic.
+        //slither-disable-next-line incorrect-equality
         if (shareRatio == 0) {
             return 0;
         }

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.deposit.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.deposit.t.sol
@@ -53,6 +53,12 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1DepositTest is Offchain
         uint256 firstShares
     ) external {
         vm.assume(uint160(alice) > type(uint160).max / 2 && uint160(bob) > type(uint160).max / 2 && alice != bob);
+        // The mint path calls `_mint` on the ERC1155 receipt, which invokes
+        // `onERC1155Received` on receiver contracts. Filter out fuzzer-
+        // generated addresses that happen to have code so the mint reverts
+        // with the asserted `ERC20InsufficientBalance` rather than an
+        // `ERC1155InvalidReceiver` from the upstream OZ contract.
+        vm.assume(alice.code.length == 0 && bob.code.length == 0);
 
         vm.prank(bob);
         TestErc20 paymentToken = new TestErc20();

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.deposit.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.deposit.t.sol
@@ -53,11 +53,6 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1DepositTest is Offchain
         uint256 firstShares
     ) external {
         vm.assume(uint160(alice) > type(uint160).max / 2 && uint160(bob) > type(uint160).max / 2 && alice != bob);
-        // The mint path calls `_mint` on the ERC1155 receipt, which invokes
-        // `onERC1155Received` on receiver contracts. Filter out fuzzer-
-        // generated addresses that happen to have code so the mint reverts
-        // with the asserted `ERC20InsufficientBalance` rather than an
-        // `ERC1155InvalidReceiver` from the upstream OZ contract.
         vm.assume(alice.code.length == 0 && bob.code.length == 0);
 
         vm.prank(bob);

--- a/test/src/concrete/vault/ERC20PriceOracleReceiptVault.maxWithdraw.t.sol
+++ b/test/src/concrete/vault/ERC20PriceOracleReceiptVault.maxWithdraw.t.sol
@@ -68,4 +68,13 @@ contract ERC20PriceOracleReceiptVaultMaxRedeemTest is ERC20PriceOracleReceiptVau
 
         assertEqUint(maxWithdraw, 0);
     }
+
+    /// ERC-4626 maxWithdraw MUST NOT revert
+    /// (https://eips.ethereum.org/EIPS/eip-4626#maxwithdraw). `id == 0` makes
+    /// `_shareRatioUserAgnostic` return 0 for this vault, which would divide
+    /// by zero inside `_calculateRedeem` without the short-circuit guard.
+    function testMaxWithdrawZeroIdDoesNotRevert(string memory name, string memory symbol, address owner) external {
+        ERC20PriceOracleReceiptVault vault = createVault(iVaultOracle, name, symbol);
+        assertEqUint(vault.maxWithdraw(owner, 0), 0);
+    }
 }

--- a/test/src/concrete/vault/ERC20PriceOracleReceiptVault.maxWithdraw.t.sol
+++ b/test/src/concrete/vault/ERC20PriceOracleReceiptVault.maxWithdraw.t.sol
@@ -77,4 +77,15 @@ contract ERC20PriceOracleReceiptVaultMaxRedeemTest is ERC20PriceOracleReceiptVau
         ERC20PriceOracleReceiptVault vault = createVault(iVaultOracle, name, symbol);
         assertEqUint(vault.maxWithdraw(owner, 0), 0);
     }
+
+    /// Fuzzing every `id` across the full uint256 range. ERC-4626 says
+    /// maxWithdraw MUST NOT revert under any input — including ids the vault
+    /// has never minted a receipt for, including `id == 0` (zero share
+    /// ratio), including caller-controlled garbage.
+    function testMaxWithdrawAnyIdDoesNotRevert(string memory name, string memory symbol, address owner, uint256 id)
+        external
+    {
+        ERC20PriceOracleReceiptVault vault = createVault(iVaultOracle, name, symbol);
+        vault.maxWithdraw(owner, id);
+    }
 }


### PR DESCRIPTION
## Summary
- ERC-4626 requires [maxWithdraw MUST NOT revert](https://eips.ethereum.org/EIPS/eip-4626#maxwithdraw).
- `ERC20PriceOracleReceiptVault._shareRatioUserAgnostic` returns `id`, so `maxWithdraw(owner, 0)` produces a zero share ratio and panics with `Panic(0x12)` inside `_calculateRedeem`. A zero share ratio means no deposit at this id has ever existed; the max withdrawable is 0. Short-circuit before the math.
- Pinned by a targeted test (`testMaxWithdrawZeroIdDoesNotRevert`) and a broad fuzz (`testMaxWithdrawAnyIdDoesNotRevert`).

Part of #303 (full ERC-4626 spec compliance is broader and remains open).

## Test plan
- [x] TDD: new tests fail against unfixed code with `Panic(0x12)`; pass after the fix.
- [x] Full non-fork suite green (341/341).
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)