### PR TITLE
feat: make setAuthorizer public for super-callable overrides

### DIFF
--- a/src/concrete/vault/OffchainAssetReceiptVault.sol
+++ b/src/concrete/vault/OffchainAssetReceiptVault.sol
@@ -372,7 +372,7 @@ contract OffchainAssetReceiptVault is IAuthorizableV1, ICertifiableV1, IAuthoriz
     /// Sets the authorizer contract. This is a critical operation and should be
     /// done with extreme care by the owner.
     /// @param newAuthorizer The new authorizer contract.
-    function setAuthorizer(IAuthorizeV1 newAuthorizer) external virtual onlyOwner {
+    function setAuthorizer(IAuthorizeV1 newAuthorizer) public virtual onlyOwner {
         _setAuthorizer(newAuthorizer);
     }
 


### PR DESCRIPTION
external setAuthorizer is overridable but downstream can only re-implement it — Solidity rejects `super.fn()` on external functions. public keeps the ABI unchanged for external callers while letting downstream extensions wrap and forward via `super.setAuthorizer(...)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated contract function visibility for internal consistency. No changes to user-facing functionality or behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rain.vats/pull/307)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->