### PR TITLE
fix #309: _msgSender spoofing via ERC1155 acceptance callbacks

### DIFF
--- a/src/concrete/receipt/Receipt.sol
+++ b/src/concrete/receipt/Receipt.sol
@@ -220,21 +220,19 @@ contract Receipt is IReceiptV3, ICloneableV2, ERC1155Upgradeable {
         override
     {
         Receipt7201Storage storage s = getStorageReceipt();
-        // The manager-supplied `operator` (the depositor/confiscator) authorizes
-        // the one transfer the manager initiated; any other transfer authorizes
-        // as its true caller. We CONSUME the operator here — read it, then clear
-        // it — so it cannot leak into a later transfer. This single-use model is
-        // necessary (not just a flag) because OZ fires the ERC1155 acceptance
-        // callback from a PRIVATE `_updateWithAcceptanceCheck`, AFTER this
-        // override returns: a reentrancy flag scoped to `_update` would already
-        // be reset before the callback runs, but a consumed (cleared) operator
-        // stays cleared, so a transfer re-entering during the callback correctly
-        // falls back to `_msgSender()`. `_msgSender()` itself is NOT overridden,
-        // so the inherited ERC1155 permission checks cannot be spoofed (#309).
+
+        // `s.operator` is the transfer initiator forwarded to the authorizer. A
+        // manager call plants it via `withOperator(...)`; `_msgSender()` is never
+        // overridden, so ERC1155 permission checks always see the true caller.
         address operator = s.operator;
         if (operator == address(0)) {
+            // No operator planted: a direct transfer, or a transfer whose operator
+            // was already consumed below (e.g. one re-entering during the
+            // acceptance callback). Authorize as the true caller.
             operator = _msgSender();
         } else {
+            // Operator planted by a manager call. Forward it once and clear it, so
+            // no later transfer in this transaction can reuse it.
             s.operator = address(0);
         }
         s.manager.authorizeReceiptTransfer3(operator, from, to, ids, amounts);

--- a/src/concrete/receipt/Receipt.sol
+++ b/src/concrete/receipt/Receipt.sol
@@ -230,6 +230,14 @@ contract Receipt is IReceiptV3, ICloneableV2, ERC1155Upgradeable {
         if (operator == address(0)) {
             operator = _msgSender();
         }
+        // Clear the stored operator now that it has been captured, BEFORE
+        // authorizing and BEFORE `super._update` fires any ERC1155 acceptance
+        // callback. Otherwise a transfer that re-enters during the callback (or
+        // a malicious authorizer) would inherit this call's operator for its own
+        // `authorizeReceiptTransfer3` instead of its true caller. Each manager
+        // call performs exactly one `_update`, so clearing here does not affect
+        // the operator the rest of this call sees.
+        s.operator = address(0);
         s.manager.authorizeReceiptTransfer3(operator, from, to, ids, amounts);
         super._update(from, to, ids, amounts);
     }

--- a/src/concrete/receipt/Receipt.sol
+++ b/src/concrete/receipt/Receipt.sol
@@ -36,11 +36,15 @@ contract Receipt is IReceiptV3, ICloneableV2, ERC1155Upgradeable {
     /// @param manager The manager of the `Receipt` contract.
     /// Set during `initialize` and cannot be changed.
     /// Intended to be a `ReceiptVault` contract.
-    /// @param sender The sender for the duration of the function call.
+    /// @param operator The authorization operator for the duration of a manager
+    /// call (the depositor/confiscator that the vault passed). Used ONLY to pass
+    /// the correct operator to `authorizeReceiptTransfer3`; it deliberately does
+    /// NOT affect `_msgSender()`, so the inherited ERC1155 functions and their
+    /// acceptance callbacks observe the true `msg.sender` and cannot be spoofed.
     /// @custom:storage-location erc7201:rain.storage.receipt.1
     struct Receipt7201Storage {
         IReceiptManagerV2 manager;
-        address sender;
+        address operator;
     }
 
     /// @dev Accessor for receipt storage.
@@ -71,36 +75,30 @@ contract Receipt is IReceiptV3, ICloneableV2, ERC1155Upgradeable {
         }
     }
 
-    /// Sets the sender for the duration of the function call. Requires that
-    /// `_msgSender()` is used consistently instead of `msg.sender` so that the
-    /// sender that is set here is actually used.
-    /// @param sender The address to set as the sender.
-    modifier withSender(address sender) {
-        _withSenderBefore(sender);
+    /// Sets the authorization operator for the duration of a manager call. This
+    /// is the address the vault passed (the depositor/confiscator) and is used
+    /// ONLY to pass the correct operator to `authorizeReceiptTransfer3` in
+    /// `_update`. It deliberately does NOT override `_msgSender()`, so the
+    /// inherited ERC1155 functions and acceptance callbacks observe the true
+    /// `msg.sender` and cannot be spoofed (see #309).
+    /// @param operator The address to set as the authorization operator.
+    modifier withOperator(address operator) {
+        _withOperatorBefore(operator);
         _;
-        _withSenderAfter();
+        _withOperatorAfter();
     }
 
-    /// Sets the sender to `sender`. Dedicated function to avoid code bloat from
-    /// using a modifier directly.
-    /// @param sender The address to set as the sender.
-    function _withSenderBefore(address sender) internal {
-        Receipt7201Storage storage s = getStorageReceipt();
-        s.sender = sender;
+    /// Sets the operator. Dedicated function to avoid code bloat from using a
+    /// modifier directly.
+    /// @param operator The address to set as the authorization operator.
+    function _withOperatorBefore(address operator) internal {
+        getStorageReceipt().operator = operator;
     }
-    /// Resets the sender to address(0). Dedicated function to avoid code bloat
+
+    /// Resets the operator to address(0). Dedicated function to avoid code bloat
     /// from using a modifier directly.
-
-    function _withSenderAfter() internal {
-        Receipt7201Storage storage s = getStorageReceipt();
-        s.sender = address(0);
-    }
-
-    /// Overrides `_msgSender` to allow `withSender` modifier to set the sender.
-    function _msgSender() internal view virtual override returns (address) {
-        Receipt7201Storage storage s = getStorageReceipt();
-        address sender = s.sender;
-        return sender == address(0) ? msg.sender : sender;
+    function _withOperatorAfter() internal {
+        getStorageReceipt().operator = address(0);
     }
 
     /// Initializes the `Receipt` so that it is usable as a clonable
@@ -182,7 +180,7 @@ contract Receipt is IReceiptV3, ICloneableV2, ERC1155Upgradeable {
         external
         virtual
         onlyManager
-        withSender(sender)
+        withOperator(sender)
     {
         _receiptInformation(sender, id, data);
         _mint(account, id, amount, data);
@@ -193,7 +191,7 @@ contract Receipt is IReceiptV3, ICloneableV2, ERC1155Upgradeable {
         external
         virtual
         onlyManager
-        withSender(sender)
+        withOperator(sender)
     {
         _receiptInformation(sender, id, data);
         _burn(account, id, amount);
@@ -207,7 +205,7 @@ contract Receipt is IReceiptV3, ICloneableV2, ERC1155Upgradeable {
         uint256 id,
         uint256 amount,
         bytes memory data
-    ) external virtual onlyManager withSender(sender) {
+    ) external virtual onlyManager withOperator(sender) {
         _safeTransferFrom(from, to, id, amount, data);
     }
 
@@ -220,8 +218,19 @@ contract Receipt is IReceiptV3, ICloneableV2, ERC1155Upgradeable {
         override
     {
         Receipt7201Storage storage s = getStorageReceipt();
-        // _msgSender = operator in OZ 5.
-        s.manager.authorizeReceiptTransfer3(_msgSender(), from, to, ids, amounts);
+        // The authorization operator is the explicit operator set by the active
+        // manager call (the depositor/confiscator the vault passed), falling
+        // back to the real caller for direct peer-to-peer transfers. This is
+        // kept separate from `_msgSender()` on purpose: `_msgSender()` is NOT
+        // overridden, so ERC1155 acceptance callbacks cannot spoof identities
+        // (#309), while `authorizeReceiptTransfer3` still receives the true
+        // initiator (e.g. a confiscator must still be seen for the
+        // confiscation-during-certification-expiry bypass).
+        address operator = s.operator;
+        if (operator == address(0)) {
+            operator = _msgSender();
+        }
+        s.manager.authorizeReceiptTransfer3(operator, from, to, ids, amounts);
         super._update(from, to, ids, amounts);
     }
 

--- a/src/concrete/receipt/Receipt.sol
+++ b/src/concrete/receipt/Receipt.sol
@@ -36,11 +36,13 @@ contract Receipt is IReceiptV3, ICloneableV2, ERC1155Upgradeable {
     /// @param manager The manager of the `Receipt` contract.
     /// Set during `initialize` and cannot be changed.
     /// Intended to be a `ReceiptVault` contract.
-    /// @param operator The authorization operator for the duration of a manager
-    /// call (the depositor/confiscator that the vault passed). Used ONLY to pass
-    /// the correct operator to `authorizeReceiptTransfer3`; it deliberately does
-    /// NOT affect `_msgSender()`, so the inherited ERC1155 functions and their
-    /// acceptance callbacks observe the true `msg.sender` and cannot be spoofed.
+    /// @param operator The authorization operator the active manager call passed
+    /// (the depositor/confiscator). It is a SINGLE-USE token: `_update` consumes
+    /// it (clears it) as it authorizes the one transfer the manager initiated, so
+    /// any later transfer — including one that re-enters during an ERC1155
+    /// acceptance callback — falls back to the true `msg.sender`. It deliberately
+    /// does NOT affect `_msgSender()`, so the inherited ERC1155 functions and
+    /// their callbacks observe the true caller and cannot be spoofed.
     /// @custom:storage-location erc7201:rain.storage.receipt.1
     struct Receipt7201Storage {
         IReceiptManagerV2 manager;
@@ -218,26 +220,23 @@ contract Receipt is IReceiptV3, ICloneableV2, ERC1155Upgradeable {
         override
     {
         Receipt7201Storage storage s = getStorageReceipt();
-        // The authorization operator is the explicit operator set by the active
-        // manager call (the depositor/confiscator the vault passed), falling
-        // back to the real caller for direct peer-to-peer transfers. This is
-        // kept separate from `_msgSender()` on purpose: `_msgSender()` is NOT
-        // overridden, so ERC1155 acceptance callbacks cannot spoof identities
-        // (#309), while `authorizeReceiptTransfer3` still receives the true
-        // initiator (e.g. a confiscator must still be seen for the
-        // confiscation-during-certification-expiry bypass).
+        // The manager-supplied `operator` (the depositor/confiscator) authorizes
+        // the one transfer the manager initiated; any other transfer authorizes
+        // as its true caller. We CONSUME the operator here — read it, then clear
+        // it — so it cannot leak into a later transfer. This single-use model is
+        // necessary (not just a flag) because OZ fires the ERC1155 acceptance
+        // callback from a PRIVATE `_updateWithAcceptanceCheck`, AFTER this
+        // override returns: a reentrancy flag scoped to `_update` would already
+        // be reset before the callback runs, but a consumed (cleared) operator
+        // stays cleared, so a transfer re-entering during the callback correctly
+        // falls back to `_msgSender()`. `_msgSender()` itself is NOT overridden,
+        // so the inherited ERC1155 permission checks cannot be spoofed (#309).
         address operator = s.operator;
         if (operator == address(0)) {
             operator = _msgSender();
+        } else {
+            s.operator = address(0);
         }
-        // Clear the stored operator now that it has been captured, BEFORE
-        // authorizing and BEFORE `super._update` fires any ERC1155 acceptance
-        // callback. Otherwise a transfer that re-enters during the callback (or
-        // a malicious authorizer) would inherit this call's operator for its own
-        // `authorizeReceiptTransfer3` instead of its true caller. Each manager
-        // call performs exactly one `_update`, so clearing here does not affect
-        // the operator the rest of this call sees.
-        s.operator = address(0);
         s.manager.authorizeReceiptTransfer3(operator, from, to, ids, amounts);
         super._update(from, to, ids, amounts);
     }

--- a/src/concrete/receipt/Receipt.sol
+++ b/src/concrete/receipt/Receipt.sol
@@ -103,6 +103,20 @@ contract Receipt is IReceiptV3, ICloneableV2, ERC1155Upgradeable {
         getStorageReceipt().operator = address(0);
     }
 
+    /// Returns the operator to authorize the current transfer as, consuming any
+    /// single-use operator a manager call planted via `withOperator`. Falls back
+    /// to the true caller when none is set (direct transfers, and transfers that
+    /// re-enter once the operator has been consumed).
+    function _consumeOperator() internal returns (address) {
+        Receipt7201Storage storage s = getStorageReceipt();
+        address operator = s.operator;
+        if (operator == address(0)) {
+            return _msgSender();
+        }
+        s.operator = address(0);
+        return operator;
+    }
+
     /// Initializes the `Receipt` so that it is usable as a clonable
     /// implementation in `ReceiptFactory`.
     /// Compatible with `ICloneableV2`.
@@ -219,23 +233,8 @@ contract Receipt is IReceiptV3, ICloneableV2, ERC1155Upgradeable {
         virtual
         override
     {
-        Receipt7201Storage storage s = getStorageReceipt();
-
-        // `s.operator` is the transfer initiator forwarded to the authorizer. A
-        // manager call plants it via `withOperator(...)`; `_msgSender()` is never
-        // overridden, so ERC1155 permission checks always see the true caller.
-        address operator = s.operator;
-        if (operator == address(0)) {
-            // No operator planted: a direct transfer, or a transfer whose operator
-            // was already consumed below (e.g. one re-entering during the
-            // acceptance callback). Authorize as the true caller.
-            operator = _msgSender();
-        } else {
-            // Operator planted by a manager call. Forward it once and clear it, so
-            // no later transfer in this transaction can reuse it.
-            s.operator = address(0);
-        }
-        s.manager.authorizeReceiptTransfer3(operator, from, to, ids, amounts);
+        address operator = _consumeOperator();
+        getStorageReceipt().manager.authorizeReceiptTransfer3(operator, from, to, ids, amounts);
         super._update(from, to, ids, amounts);
     }
 

--- a/test/concrete/ApprovalSpoofReceiver.sol
+++ b/test/concrete/ApprovalSpoofReceiver.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IERC1155Receiver} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155Receiver.sol";
+import {IERC1155} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155.sol";
+
+/// @title ApprovalSpoofReceiver
+/// @notice TEST receiver that re-enters the receipt during the ERC1155
+/// acceptance callback and grants `attacker` operator approval. Pre-#309-fix
+/// this was spoofed onto the depositor (the overridden `_msgSender()`);
+/// post-fix it lands on this contract itself (the true `msg.sender`).
+contract ApprovalSpoofReceiver is IERC1155Receiver {
+    IERC1155 internal immutable iReceipt;
+    address internal immutable iAttacker;
+
+    constructor(IERC1155 receipt, address attacker) {
+        iReceipt = receipt;
+        iAttacker = attacker;
+    }
+
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external returns (bytes4) {
+        iReceipt.setApprovalForAll(iAttacker, true);
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return true;
+    }
+}

--- a/test/concrete/AtomicDrainReceiver.sol
+++ b/test/concrete/AtomicDrainReceiver.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IERC1155Receiver} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155Receiver.sol";
+import {IERC1155} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155.sol";
+
+/// @title AtomicDrainReceiver
+/// @notice TEST receiver that re-enters the receipt during the ERC1155
+/// acceptance callback and tries to drain the victim's pre-existing receipts in
+/// the same transaction. Pre-#309-fix the spoof made `_msgSender()` the victim,
+/// so OZ's `from == sender` check passed; post-fix `_msgSender()` is this
+/// contract, so the transfer reverts with `ERC1155MissingApprovalForAll`.
+contract AtomicDrainReceiver is IERC1155Receiver {
+    IERC1155 internal immutable iReceipt;
+    address internal immutable iVictim;
+    address internal immutable iAttacker;
+    uint256 internal immutable iDrainId;
+    uint256 internal immutable iDrainAmount;
+
+    constructor(IERC1155 receipt, address victim, address attacker, uint256 drainId, uint256 drainAmount) {
+        iReceipt = receipt;
+        iVictim = victim;
+        iAttacker = attacker;
+        iDrainId = drainId;
+        iDrainAmount = drainAmount;
+    }
+
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external returns (bytes4) {
+        iReceipt.safeTransferFrom(iVictim, iAttacker, iDrainId, iDrainAmount, "");
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return true;
+    }
+}

--- a/test/concrete/BatchDrainReceiver.sol
+++ b/test/concrete/BatchDrainReceiver.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IERC1155Receiver} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155Receiver.sol";
+import {IERC1155} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155.sol";
+
+/// @title BatchDrainReceiver
+/// @notice TEST receiver that re-enters the receipt during the ERC1155
+/// acceptance callback and tries to drain the victim's pre-existing receipts via
+/// `safeBatchTransferFrom`. The batch analogue of `AtomicDrainReceiver` — covers
+/// the batch `_update` / acceptance path. Post-#309-fix `_msgSender()` is this
+/// contract, so the transfer reverts with `ERC1155MissingApprovalForAll`.
+contract BatchDrainReceiver is IERC1155Receiver {
+    IERC1155 internal immutable iReceipt;
+    address internal immutable iVictim;
+    address internal immutable iAttacker;
+    uint256 internal immutable iDrainId;
+    uint256 internal immutable iDrainAmount;
+
+    constructor(IERC1155 receipt, address victim, address attacker, uint256 drainId, uint256 drainAmount) {
+        iReceipt = receipt;
+        iVictim = victim;
+        iAttacker = attacker;
+        iDrainId = drainId;
+        iDrainAmount = drainAmount;
+    }
+
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external returns (bytes4) {
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = iDrainId;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = iDrainAmount;
+        iReceipt.safeBatchTransferFrom(iVictim, iAttacker, ids, amounts, "");
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return true;
+    }
+}

--- a/test/concrete/BenignReceiver.sol
+++ b/test/concrete/BenignReceiver.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IERC1155Receiver} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155Receiver.sol";
+
+/// @title BenignReceiver
+/// @notice TEST receiver that does nothing in the acceptance callback — models a
+/// trusted recipient such as a pass-through mint/deposit wrapper.
+contract BenignReceiver is IERC1155Receiver {
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external pure returns (bytes4) {
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return true;
+    }
+}

--- a/test/concrete/FreeTransferReceiptManager.sol
+++ b/test/concrete/FreeTransferReceiptManager.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IReceiptV3} from "src/interface/IReceiptV3.sol";
+import {IReceiptManagerV2} from "src/interface/IReceiptManagerV2.sol";
+
+/// @title FreeTransferReceiptManager
+/// @notice TEST manager that authorizes ALL receipt transfers (no-op
+/// `authorizeReceiptTransfer3`) — the worst case for the #309 spoofing bug,
+/// where receipts are unconditionally transferable and there is no per-transfer
+/// authorization hook to lean on (e.g. any vault inheriting the base
+/// `ReceiptVault` no-op authorizer). `mint` takes an explicit `sender` so tests
+/// can drive the operator directly, the way a vault passes `_msgSender()` (the
+/// depositor) into `managerMint`.
+contract FreeTransferReceiptManager is IReceiptManagerV2 {
+    function authorizeReceiptTransfer3(address, address, address, uint256[] memory, uint256[] memory) external {}
+
+    function mint(IReceiptV3 receipt, address sender, address account, uint256 id, uint256 amount, bytes memory data)
+        external
+    {
+        receipt.managerMint(sender, account, id, amount, data);
+    }
+}

--- a/test/concrete/FreezeSimReceiptManager.sol
+++ b/test/concrete/FreezeSimReceiptManager.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IReceiptV3} from "src/interface/IReceiptV3.sol";
+import {IReceiptManagerV2} from "src/interface/IReceiptManagerV2.sol";
+
+/// Thrown by `FreezeSimReceiptManager` when a non-mint/burn transfer is
+/// attempted by an operator that is not the privileged handler.
+error NotPrivileged(address operator);
+
+/// @title FreezeSimReceiptManager
+/// @notice TEST manager that simulates a frozen system: mints and burns (the
+/// `address(0)` legs) are always allowed for repair, but any peer-to-peer
+/// receipt transfer is allowed ONLY when the authorization `operator` is the
+/// designated privileged handler (e.g. a confiscator). It lets tests prove the
+/// security consequence of the #309 consume-once operator — that a privileged
+/// outer operator does NOT leak into a transfer re-entering during an acceptance
+/// callback (which would otherwise authorize with the leaked privilege).
+contract FreezeSimReceiptManager is IReceiptManagerV2 {
+    address public immutable privileged;
+    address public lastOperator;
+
+    constructor(address privileged_) {
+        privileged = privileged_;
+    }
+
+    function authorizeReceiptTransfer3(address operator, address from, address to, uint256[] memory, uint256[] memory)
+        external
+    {
+        lastOperator = operator;
+        // Minting (`from == 0`) and burning (`to == 0`) are always permitted so
+        // holdings can be set up and repaired.
+        if (from == address(0) || to == address(0)) {
+            return;
+        }
+        // Otherwise only the privileged handler may move receipts.
+        if (operator != privileged) {
+            revert NotPrivileged(operator);
+        }
+    }
+
+    function mint(IReceiptV3 receipt, address sender, address account, uint256 id, uint256 amount, bytes memory data)
+        external
+    {
+        receipt.managerMint(sender, account, id, amount, data);
+    }
+
+    function transferFrom(
+        IReceiptV3 receipt,
+        address sender,
+        address from,
+        address to,
+        uint256 id,
+        uint256 amount,
+        bytes memory data
+    ) external {
+        receipt.managerTransferFrom(sender, from, to, id, amount, data);
+    }
+}

--- a/test/concrete/ManagerForgeReceiver.sol
+++ b/test/concrete/ManagerForgeReceiver.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IERC1155Receiver} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155Receiver.sol";
+import {IReceiptV3} from "src/interface/IReceiptV3.sol";
+
+/// @title ManagerForgeReceiver
+/// @notice TEST receiver that, during the ERC1155 acceptance callback, tries to
+/// forge a manager-only `managerMint` while NOT being the manager. The fix does
+/// not override `_msgSender()`, so `_onlyManager` sees this contract (the true
+/// caller) rather than any stored/spoofed identity and reverts `OnlyManager`,
+/// proving a malicious receiver cannot hijack the manager authorization from
+/// inside a callback (e.g. to forge mints or confiscations).
+contract ManagerForgeReceiver is IERC1155Receiver {
+    IReceiptV3 internal immutable iReceipt;
+    uint256 internal immutable iForgeId;
+    uint256 internal immutable iForgeAmount;
+
+    constructor(IReceiptV3 receipt, uint256 forgeId, uint256 forgeAmount) {
+        iReceipt = receipt;
+        iForgeId = forgeId;
+        iForgeAmount = forgeAmount;
+    }
+
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external returns (bytes4) {
+        // Attempt to mint to ourselves as if we were the manager. `_onlyManager`
+        // must reject this because `_msgSender()` is this contract, not the
+        // manager — it reverts the call and unwinds the outer manager operation.
+        iReceipt.managerMint(address(this), address(this), iForgeId, iForgeAmount, "");
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return true;
+    }
+}

--- a/test/concrete/RecordingReceiver.sol
+++ b/test/concrete/RecordingReceiver.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IERC1155Receiver} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155Receiver.sol";
+
+/// @title RecordingReceiver
+/// @notice TEST receiver that records the `operator` it is told about in the
+/// ERC1155 acceptance callback, so tests can assert the callback observes the
+/// true caller rather than a spoofed identity.
+contract RecordingReceiver is IERC1155Receiver {
+    address public lastOperator;
+
+    function onERC1155Received(address operator, address, uint256, uint256, bytes calldata) external returns (bytes4) {
+        lastOperator = operator;
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address operator, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        returns (bytes4)
+    {
+        lastOperator = operator;
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return true;
+    }
+}

--- a/test/concrete/ReentrantDepositReceiver.sol
+++ b/test/concrete/ReentrantDepositReceiver.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IERC1155Receiver} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155Receiver.sol";
+
+/// @dev Minimal view of the vault `deposit` entrypoint the receiver re-enters.
+interface IReentrantDepositTarget {
+    function deposit(uint256 assets, address receiver, uint256 depositMinShareRatio, bytes memory receiptInformation)
+        external
+        returns (uint256);
+}
+
+/// @title ReentrantDepositReceiver
+/// @notice TEST receiver that re-enters the VAULT's `deposit` during the ERC1155
+/// acceptance callback fired by the outer deposit's receipt mint. The vault's
+/// `_deposit` is `nonReentrant`, so the nested deposit must revert with
+/// `ReentrancyGuardReentrantCall`, reverting the whole outer deposit. This is the
+/// end-to-end guard that backstops the #309 callback surface: even with the fix
+/// making the callback observe the true caller, the shared reentrancy guard also
+/// forbids re-entering any value-moving vault flow from inside the callback.
+contract ReentrantDepositReceiver is IERC1155Receiver {
+    IReentrantDepositTarget internal immutable iVault;
+    uint256 internal immutable iAssets;
+
+    constructor(IReentrantDepositTarget vault, uint256 assets) {
+        iVault = vault;
+        iAssets = assets;
+    }
+
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external returns (bytes4) {
+        iVault.deposit(iAssets, address(this), 0, "");
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return true;
+    }
+}

--- a/test/concrete/ReentrantLeakReceiver.sol
+++ b/test/concrete/ReentrantLeakReceiver.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IERC1155Receiver} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155Receiver.sol";
+import {IERC1155} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155.sol";
+
+/// @title ReentrantLeakReceiver
+/// @notice TEST receiver that, during the ERC1155 acceptance callback, tries to
+/// forward its just-received tokens to an attacker by re-entering the receipt.
+/// It swallows any revert (try/catch) and records whether the nested transfer
+/// succeeded, so a test can assert the transfer was DENIED — i.e. the privileged
+/// operator of the outer manager call did not leak into this re-entrant transfer
+/// (it authorized as this contract, which is unprivileged).
+contract ReentrantLeakReceiver is IERC1155Receiver {
+    IERC1155 internal immutable iReceipt;
+    address internal immutable iAttacker;
+    uint256 internal immutable iId;
+    uint256 internal immutable iAmount;
+
+    bool public nestedAttempted;
+    bool public nestedSucceeded;
+    /// Revert data captured from the denied nested transfer. Captured in THIS
+    /// contract's frame (which does not revert), so it survives even though the
+    /// nested call's own state changes are rolled back.
+    bytes public nestedRevertData;
+
+    constructor(IERC1155 receipt, address attacker, uint256 id, uint256 amount) {
+        iReceipt = receipt;
+        iAttacker = attacker;
+        iId = id;
+        iAmount = amount;
+    }
+
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external returns (bytes4) {
+        nestedAttempted = true;
+        try iReceipt.safeTransferFrom(address(this), iAttacker, iId, iAmount, "") {
+            nestedSucceeded = true;
+        } catch (bytes memory err) {
+            nestedSucceeded = false;
+            nestedRevertData = err;
+        }
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return true;
+    }
+}

--- a/test/concrete/ReentrantTransferReceiver.sol
+++ b/test/concrete/ReentrantTransferReceiver.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IERC1155Receiver} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155Receiver.sol";
+import {IERC1155} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155.sol";
+
+/// @title ReentrantTransferReceiver
+/// @notice TEST receiver that, during the ERC1155 acceptance callback, transfers
+/// its OWN just-received tokens onward (a legitimate transfer it is allowed to
+/// make as the owner). Used to observe which operator identity the receipt
+/// forwards to `authorizeReceiptTransfer3` for a transfer that re-enters during
+/// a manager call.
+contract ReentrantTransferReceiver is IERC1155Receiver {
+    IERC1155 internal immutable iReceipt;
+    address internal immutable iTo;
+    uint256 internal immutable iId;
+    uint256 internal immutable iAmount;
+
+    constructor(IERC1155 receipt, address to, uint256 id, uint256 amount) {
+        iReceipt = receipt;
+        iTo = to;
+        iId = id;
+        iAmount = amount;
+    }
+
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external returns (bytes4) {
+        iReceipt.safeTransferFrom(address(this), iTo, iId, iAmount, "");
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return true;
+    }
+}

--- a/test/concrete/SpyReceiptManager.sol
+++ b/test/concrete/SpyReceiptManager.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IReceiptV3} from "src/interface/IReceiptV3.sol";
+import {IReceiptManagerV2} from "src/interface/IReceiptManagerV2.sol";
+
+/// @title SpyReceiptManager
+/// @notice TEST manager that authorizes ALL transfers and records the
+/// `(operator, from, to)` of the most recent `authorizeReceiptTransfer3` call,
+/// so tests can assert exactly what operator identity the receipt forwards. The
+/// `mint`/`burn`/`transferFrom` helpers forward to the manager-gated functions
+/// with an explicit `sender`.
+contract SpyReceiptManager is IReceiptManagerV2 {
+    address public lastOperator;
+    address public lastFrom;
+    address public lastTo;
+
+    function authorizeReceiptTransfer3(address operator, address from, address to, uint256[] memory, uint256[] memory)
+        external
+    {
+        lastOperator = operator;
+        lastFrom = from;
+        lastTo = to;
+    }
+
+    function mint(IReceiptV3 receipt, address sender, address account, uint256 id, uint256 amount, bytes memory data)
+        external
+    {
+        receipt.managerMint(sender, account, id, amount, data);
+    }
+
+    function burn(IReceiptV3 receipt, address sender, address account, uint256 id, uint256 amount, bytes memory data)
+        external
+    {
+        receipt.managerBurn(sender, account, id, amount, data);
+    }
+
+    function transferFrom(
+        IReceiptV3 receipt,
+        address sender,
+        address from,
+        address to,
+        uint256 id,
+        uint256 amount,
+        bytes memory data
+    ) external {
+        receipt.managerTransferFrom(sender, from, to, id, amount, data);
+    }
+}

--- a/test/src/concrete/receipt/Receipt.msgSenderSpoof.t.sol
+++ b/test/src/concrete/receipt/Receipt.msgSenderSpoof.t.sol
@@ -4,43 +4,9 @@ pragma solidity =0.8.25;
 
 import {Receipt as ReceiptContract} from "src/concrete/receipt/Receipt.sol";
 import {TestReceiptManager} from "test/concrete/TestReceiptManager.sol";
+import {ApprovalSpoofReceiver} from "test/concrete/ApprovalSpoofReceiver.sol";
 import {ReceiptFactoryTest} from "test/abstract/ReceiptFactoryTest.sol";
-import {IERC1155Receiver} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155Receiver.sol";
 import {IERC1155} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155.sol";
-
-/// @title MaliciousReceiver
-/// @notice An ERC1155 receiver that, during the acceptance callback fired by
-/// `_mint`, re-enters the receipt and grants `attacker` operator approval.
-/// Because `managerMint` holds `withSender(sender)` for the whole call, the
-/// receipt's `_msgSender()` returns the spoofed depositor at callback time, so
-/// the approval is recorded as if the depositor authorized it.
-contract MaliciousReceiver is IERC1155Receiver {
-    IERC1155 internal immutable iReceipt;
-    address internal immutable iAttacker;
-
-    constructor(IERC1155 receipt, address attacker) {
-        iReceipt = receipt;
-        iAttacker = attacker;
-    }
-
-    /// Re-enters the receipt mid-mint to grant the attacker operator approval.
-    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external returns (bytes4) {
-        iReceipt.setApprovalForAll(iAttacker, true);
-        return IERC1155Receiver.onERC1155Received.selector;
-    }
-
-    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
-        external
-        pure
-        returns (bytes4)
-    {
-        return IERC1155Receiver.onERC1155BatchReceived.selector;
-    }
-
-    function supportsInterface(bytes4) external pure returns (bool) {
-        return true;
-    }
-}
 
 /// @title ReceiptMsgSenderSpoofTest
 /// @notice Regression test for issue #309: an ERC1155 acceptance callback must
@@ -65,7 +31,7 @@ contract ReceiptMsgSenderSpoofTest is ReceiptFactoryTest {
         ReceiptContract receipt =
             ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
 
-        MaliciousReceiver maliciousReceiver = new MaliciousReceiver(IERC1155(address(receipt)), attacker);
+        ApprovalSpoofReceiver maliciousReceiver = new ApprovalSpoofReceiver(IERC1155(address(receipt)), attacker);
 
         // The mint transfers from address(0) to the malicious receiver; both
         // must be authorized for `_update` to pass.

--- a/test/src/concrete/receipt/Receipt.msgSenderSpoof.t.sol
+++ b/test/src/concrete/receipt/Receipt.msgSenderSpoof.t.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Receipt as ReceiptContract} from "src/concrete/receipt/Receipt.sol";
+import {TestReceiptManager} from "test/concrete/TestReceiptManager.sol";
+import {ReceiptFactoryTest} from "test/abstract/ReceiptFactoryTest.sol";
+import {IERC1155Receiver} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155Receiver.sol";
+import {IERC1155} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155.sol";
+
+/// @title MaliciousReceiver
+/// @notice An ERC1155 receiver that, during the acceptance callback fired by
+/// `_mint`, re-enters the receipt and grants `attacker` operator approval.
+/// Because `managerMint` holds `withSender(sender)` for the whole call, the
+/// receipt's `_msgSender()` returns the spoofed depositor at callback time, so
+/// the approval is recorded as if the depositor authorized it.
+contract MaliciousReceiver is IERC1155Receiver {
+    IERC1155 internal immutable iReceipt;
+    address internal immutable iAttacker;
+
+    constructor(IERC1155 receipt, address attacker) {
+        iReceipt = receipt;
+        iAttacker = attacker;
+    }
+
+    /// Re-enters the receipt mid-mint to grant the attacker operator approval.
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external returns (bytes4) {
+        iReceipt.setApprovalForAll(iAttacker, true);
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return true;
+    }
+}
+
+/// @title ReceiptMsgSenderSpoofTest
+/// @notice Demonstrates issue #309: ERC1155 acceptance callback enables
+/// persistent operator approval via `_msgSender` spoofing.
+contract ReceiptMsgSenderSpoofTest is ReceiptFactoryTest {
+    /// During `managerMint(victim, maliciousReceiver, ...)` the `withSender`
+    /// modifier sets the receipt's stored sender to `victim` for the whole
+    /// call. `_mint` then fires `onERC1155Received` on the malicious receiver,
+    /// which calls `setApprovalForAll(attacker, true)`. The receipt's
+    /// `_msgSender()` returns the spoofed `victim`, so the approval is recorded
+    /// as `isApprovedForAll[victim][attacker] == true` — an approval the victim
+    /// never made, letting the attacker drain all of the victim's receipts and
+    /// block redemption of the underlying shares/assets.
+    ///
+    /// This test asserts the (currently buggy) spoofed approval IS granted, so
+    /// it passes against the vulnerable code and serves as an executable PoC for
+    /// #309. When #309 is fixed the assertions should be inverted: the callback
+    /// must observe the malicious receiver as `msg.sender`, so the victim must
+    /// NOT end up approving the attacker.
+    function testReceiptMsgSenderSpoofGrantsOperatorApproval(uint256 id, uint256 amount, bytes memory data) external {
+        amount = bound(amount, 1, type(uint256).max);
+
+        address victim = makeAddr("victim");
+        address attacker = makeAddr("attacker");
+
+        TestReceiptManager testManager = new TestReceiptManager();
+        ReceiptContract receipt =
+            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
+
+        MaliciousReceiver maliciousReceiver = new MaliciousReceiver(IERC1155(address(receipt)), attacker);
+
+        // The mint transfers from address(0) to the malicious receiver; both
+        // must be authorized for `_update` to pass.
+        testManager.setFrom(address(0));
+        testManager.setTo(address(maliciousReceiver));
+
+        // The victim has not approved the attacker before the deposit.
+        assertFalse(receipt.isApprovedForAll(victim, attacker), "precondition: no approval");
+
+        // The vault calls managerMint(victim, maliciousReceiver, ...) when the
+        // victim deposits with the malicious contract as `receiver`. The receipt
+        // sender is the victim (TestReceiptManager forwards its own msg.sender).
+        vm.prank(victim);
+        testManager.managerMint(receipt, address(maliciousReceiver), id, amount, data);
+
+        // BUG (#309): the malicious receiver's callback granted the attacker
+        // operator approval over the VICTIM's receipts, spoofed as the victim.
+        assertTrue(
+            receipt.isApprovedForAll(victim, attacker),
+            "victim's identity was spoofed to grant the attacker operator approval"
+        );
+
+        // The attacker did NOT receive the approval under its own identity — the
+        // whole point is that it was attributed to the victim instead.
+        assertFalse(
+            receipt.isApprovedForAll(address(maliciousReceiver), attacker),
+            "approval was attributed to the victim, not the malicious receiver"
+        );
+    }
+}

--- a/test/src/concrete/receipt/Receipt.msgSenderSpoof.t.sol
+++ b/test/src/concrete/receipt/Receipt.msgSenderSpoof.t.sol
@@ -43,23 +43,18 @@ contract MaliciousReceiver is IERC1155Receiver {
 }
 
 /// @title ReceiptMsgSenderSpoofTest
-/// @notice Demonstrates issue #309: ERC1155 acceptance callback enables
-/// persistent operator approval via `_msgSender` spoofing.
+/// @notice Regression test for issue #309: an ERC1155 acceptance callback must
+/// NOT be able to spoof the depositor's identity. With the fix (no `_msgSender`
+/// override), the callback observes the true `msg.sender` (the malicious
+/// receiver), so a `setApprovalForAll` made during the callback lands on the
+/// receiver itself, never on the spoofed depositor.
 contract ReceiptMsgSenderSpoofTest is ReceiptFactoryTest {
-    /// During `managerMint(victim, maliciousReceiver, ...)` the `withSender`
-    /// modifier sets the receipt's stored sender to `victim` for the whole
-    /// call. `_mint` then fires `onERC1155Received` on the malicious receiver,
-    /// which calls `setApprovalForAll(attacker, true)`. The receipt's
-    /// `_msgSender()` returns the spoofed `victim`, so the approval is recorded
-    /// as `isApprovedForAll[victim][attacker] == true` — an approval the victim
-    /// never made, letting the attacker drain all of the victim's receipts and
-    /// block redemption of the underlying shares/assets.
-    ///
-    /// This test asserts the (currently buggy) spoofed approval IS granted, so
-    /// it passes against the vulnerable code and serves as an executable PoC for
-    /// #309. When #309 is fixed the assertions should be inverted: the callback
-    /// must observe the malicious receiver as `msg.sender`, so the victim must
-    /// NOT end up approving the attacker.
+    /// The vault calls `managerMint(victim, maliciousReceiver, ...)` when the
+    /// victim deposits with a malicious contract as `receiver`. `_mint` fires
+    /// `onERC1155Received` on the malicious receiver, which calls
+    /// `setApprovalForAll(attacker, true)`. Pre-fix this was recorded as the
+    /// victim (spoofed `_msgSender()`); post-fix it is recorded as the malicious
+    /// receiver (the true caller), so the victim is never made to approve anyone.
     function testReceiptMsgSenderSpoofGrantsOperatorApproval(uint256 id, uint256 amount, bytes memory data) external {
         amount = bound(amount, 1, type(uint256).max);
 
@@ -77,27 +72,22 @@ contract ReceiptMsgSenderSpoofTest is ReceiptFactoryTest {
         testManager.setFrom(address(0));
         testManager.setTo(address(maliciousReceiver));
 
-        // The victim has not approved the attacker before the deposit.
         assertFalse(receipt.isApprovedForAll(victim, attacker), "precondition: no approval");
 
-        // The vault calls managerMint(victim, maliciousReceiver, ...) when the
-        // victim deposits with the malicious contract as `receiver`. The receipt
-        // sender is the victim (TestReceiptManager forwards its own msg.sender).
         vm.prank(victim);
         testManager.managerMint(receipt, address(maliciousReceiver), id, amount, data);
 
-        // BUG (#309): the malicious receiver's callback granted the attacker
-        // operator approval over the VICTIM's receipts, spoofed as the victim.
-        assertTrue(
-            receipt.isApprovedForAll(victim, attacker),
-            "victim's identity was spoofed to grant the attacker operator approval"
+        // FIXED (#309): the spoof is gone. The victim was NOT made to approve the
+        // attacker...
+        assertFalse(
+            receipt.isApprovedForAll(victim, attacker), "victim must not be spoofed into approving the attacker"
         );
 
-        // The attacker did NOT receive the approval under its own identity — the
-        // whole point is that it was attributed to the victim instead.
-        assertFalse(
+        // ...the approval the malicious callback made is attributed to the
+        // malicious receiver itself (the true `msg.sender`), which is harmless.
+        assertTrue(
             receipt.isApprovedForAll(address(maliciousReceiver), attacker),
-            "approval was attributed to the victim, not the malicious receiver"
+            "callback approval lands on the true caller, not the victim"
         );
     }
 }

--- a/test/src/concrete/receipt/Receipt.operatorIdentity.t.sol
+++ b/test/src/concrete/receipt/Receipt.operatorIdentity.t.sol
@@ -232,5 +232,12 @@ contract ReceiptOperatorIdentityTest is ReceiptFactoryTest {
             address(receiver),
             "re-entrant transfer operator is its true caller, not the stale outer operator"
         );
+
+        // The legitimate nested forward also SUCCEEDS end-to-end: a receiver
+        // moving its own just-received tokens during the callback is authorized
+        // as itself, so the balances actually move. This is the benign case the
+        // consume-once must not break.
+        assertEq(receipt.balanceOf(thirdParty, id), amount, "forwarded tokens landed at the third party");
+        assertEq(receipt.balanceOf(address(receiver), id), 0, "receiver forwarded everything it received");
     }
 }

--- a/test/src/concrete/receipt/Receipt.operatorIdentity.t.sol
+++ b/test/src/concrete/receipt/Receipt.operatorIdentity.t.sol
@@ -3,76 +3,9 @@
 pragma solidity =0.8.25;
 
 import {Receipt as ReceiptContract} from "src/concrete/receipt/Receipt.sol";
-import {IReceiptV3} from "src/interface/IReceiptV3.sol";
-import {IReceiptManagerV2} from "src/interface/IReceiptManagerV2.sol";
 import {ReceiptFactoryTest} from "test/abstract/ReceiptFactoryTest.sol";
-import {IERC1155Receiver} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155Receiver.sol";
-
-/// @title SpyReceiptManager
-/// @notice Manager that authorizes ALL transfers and records the
-/// `(operator, from, to)` of the most recent `authorizeReceiptTransfer3` call,
-/// so tests can assert exactly what operator identity the receipt forwards. The
-/// `mint`/`burn`/`transferFrom` helpers forward to the manager-gated functions
-/// with an explicit `sender`.
-contract SpyReceiptManager is IReceiptManagerV2 {
-    address public lastOperator;
-    address public lastFrom;
-    address public lastTo;
-
-    function authorizeReceiptTransfer3(address operator, address from, address to, uint256[] memory, uint256[] memory)
-        external
-    {
-        lastOperator = operator;
-        lastFrom = from;
-        lastTo = to;
-    }
-
-    function mint(IReceiptV3 receipt, address sender, address account, uint256 id, uint256 amount, bytes memory data)
-        external
-    {
-        receipt.managerMint(sender, account, id, amount, data);
-    }
-
-    function burn(IReceiptV3 receipt, address sender, address account, uint256 id, uint256 amount, bytes memory data)
-        external
-    {
-        receipt.managerBurn(sender, account, id, amount, data);
-    }
-
-    function transferFrom(
-        IReceiptV3 receipt,
-        address sender,
-        address from,
-        address to,
-        uint256 id,
-        uint256 amount,
-        bytes memory data
-    ) external {
-        receipt.managerTransferFrom(sender, from, to, id, amount, data);
-    }
-}
-
-/// Records the `operator` it is told about in the ERC1155 acceptance callback.
-contract RecordingReceiver is IERC1155Receiver {
-    address public lastOperator;
-
-    function onERC1155Received(address operator, address, uint256, uint256, bytes calldata) external returns (bytes4) {
-        lastOperator = operator;
-        return IERC1155Receiver.onERC1155Received.selector;
-    }
-
-    function onERC1155BatchReceived(address operator, address, uint256[] calldata, uint256[] calldata, bytes calldata)
-        external
-        returns (bytes4)
-    {
-        lastOperator = operator;
-        return IERC1155Receiver.onERC1155BatchReceived.selector;
-    }
-
-    function supportsInterface(bytes4) external pure returns (bool) {
-        return true;
-    }
-}
+import {SpyReceiptManager} from "test/concrete/SpyReceiptManager.sol";
+import {RecordingReceiver} from "test/concrete/RecordingReceiver.sol";
 
 /// @title ReceiptOperatorIdentityTest
 /// @notice Validates the operator identity the #309 fix forwards to

--- a/test/src/concrete/receipt/Receipt.operatorIdentity.t.sol
+++ b/test/src/concrete/receipt/Receipt.operatorIdentity.t.sol
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Receipt as ReceiptContract} from "src/concrete/receipt/Receipt.sol";
+import {IReceiptV3} from "src/interface/IReceiptV3.sol";
+import {IReceiptManagerV2} from "src/interface/IReceiptManagerV2.sol";
+import {ReceiptFactoryTest} from "test/abstract/ReceiptFactoryTest.sol";
+import {IERC1155Receiver} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155Receiver.sol";
+
+/// @title SpyReceiptManager
+/// @notice Manager that authorizes ALL transfers and records the
+/// `(operator, from, to)` of the most recent `authorizeReceiptTransfer3` call,
+/// so tests can assert exactly what operator identity the receipt forwards. The
+/// `mint`/`burn`/`transferFrom` helpers forward to the manager-gated functions
+/// with an explicit `sender`.
+contract SpyReceiptManager is IReceiptManagerV2 {
+    address public lastOperator;
+    address public lastFrom;
+    address public lastTo;
+
+    function authorizeReceiptTransfer3(address operator, address from, address to, uint256[] memory, uint256[] memory)
+        external
+    {
+        lastOperator = operator;
+        lastFrom = from;
+        lastTo = to;
+    }
+
+    function mint(IReceiptV3 receipt, address sender, address account, uint256 id, uint256 amount, bytes memory data)
+        external
+    {
+        receipt.managerMint(sender, account, id, amount, data);
+    }
+
+    function burn(IReceiptV3 receipt, address sender, address account, uint256 id, uint256 amount, bytes memory data)
+        external
+    {
+        receipt.managerBurn(sender, account, id, amount, data);
+    }
+
+    function transferFrom(
+        IReceiptV3 receipt,
+        address sender,
+        address from,
+        address to,
+        uint256 id,
+        uint256 amount,
+        bytes memory data
+    ) external {
+        receipt.managerTransferFrom(sender, from, to, id, amount, data);
+    }
+}
+
+/// Records the `operator` it is told about in the ERC1155 acceptance callback.
+contract RecordingReceiver is IERC1155Receiver {
+    address public lastOperator;
+
+    function onERC1155Received(address operator, address, uint256, uint256, bytes calldata) external returns (bytes4) {
+        lastOperator = operator;
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address operator, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        returns (bytes4)
+    {
+        lastOperator = operator;
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return true;
+    }
+}
+
+/// @title ReceiptOperatorIdentityTest
+/// @notice Validates the operator identity the #309 fix forwards to
+/// `authorizeReceiptTransfer3`: it must be the true initiator (the explicit
+/// `sender` the vault passes for manager calls, the real caller for direct
+/// peer transfers), never the vault and never spoofable. Also confirms the
+/// acceptance callback observes the true `msg.sender`, and that the operator is
+/// scoped to the manager call (reset afterwards).
+contract ReceiptOperatorIdentityTest is ReceiptFactoryTest {
+    function _setup() internal returns (SpyReceiptManager manager, ReceiptContract receipt) {
+        manager = new SpyReceiptManager();
+        receipt = ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(manager))));
+    }
+
+    /// managerMint forwards the explicit `sender` as the authorization operator.
+    function testManagerMintOperatorIsSender(uint256 id, uint256 amount) external {
+        amount = bound(amount, 1, type(uint128).max);
+        (SpyReceiptManager manager, ReceiptContract receipt) = _setup();
+        address sender = makeAddr("sender");
+        address account = makeAddr("account");
+
+        manager.mint(receipt, sender, account, id, amount, "");
+
+        assertEq(manager.lastOperator(), sender, "mint operator is the explicit sender");
+        assertEq(manager.lastFrom(), address(0));
+        assertEq(manager.lastTo(), account);
+    }
+
+    /// managerBurn forwards the explicit `sender` as the authorization operator.
+    function testManagerBurnOperatorIsSender(uint256 id, uint256 amount) external {
+        amount = bound(amount, 1, type(uint128).max);
+        (SpyReceiptManager manager, ReceiptContract receipt) = _setup();
+        address holder = makeAddr("holder");
+        address burnSender = makeAddr("burnSender");
+
+        manager.mint(receipt, makeAddr("mintSender"), holder, id, amount, "");
+        manager.burn(receipt, burnSender, holder, id, amount, "");
+
+        assertEq(manager.lastOperator(), burnSender, "burn operator is the explicit sender");
+        assertEq(manager.lastFrom(), holder);
+        assertEq(manager.lastTo(), address(0));
+    }
+
+    /// managerTransferFrom forwards the explicit `sender` (e.g. a confiscator)
+    /// as the authorization operator — preserving the confiscation authz path.
+    function testManagerTransferFromOperatorIsSender(uint256 id, uint256 amount) external {
+        amount = bound(amount, 1, type(uint128).max);
+        (SpyReceiptManager manager, ReceiptContract receipt) = _setup();
+        address from = makeAddr("from");
+        address to = makeAddr("to");
+        address confiscator = makeAddr("confiscator");
+
+        manager.mint(receipt, makeAddr("mintSender"), from, id, amount, "");
+        manager.transferFrom(receipt, confiscator, from, to, id, amount, "");
+
+        assertEq(manager.lastOperator(), confiscator, "transfer operator is the explicit sender");
+        assertEq(manager.lastFrom(), from);
+        assertEq(manager.lastTo(), to);
+    }
+
+    /// A direct peer-to-peer transfer (no manager call) forwards the REAL caller
+    /// as the operator — `_msgSender()` is no longer overridden.
+    function testDirectTransferOperatorIsCaller(uint256 id, uint256 amount) external {
+        amount = bound(amount, 1, type(uint128).max);
+        (SpyReceiptManager manager, ReceiptContract receipt) = _setup();
+        address alice = makeAddr("alice");
+        address bob = makeAddr("bob");
+
+        manager.mint(receipt, alice, alice, id, amount, "");
+
+        vm.prank(alice);
+        receipt.safeTransferFrom(alice, bob, id, amount, "");
+
+        assertEq(manager.lastOperator(), alice, "direct transfer operator is the caller");
+        assertEq(manager.lastFrom(), alice);
+        assertEq(manager.lastTo(), bob);
+    }
+
+    /// An approved-operator transfer forwards the OPERATOR (the caller), not the
+    /// token owner — standard ERC1155 operator semantics, preserved.
+    function testApprovedOperatorTransferOperatorIsOperator(uint256 id, uint256 amount) external {
+        amount = bound(amount, 1, type(uint128).max);
+        (SpyReceiptManager manager, ReceiptContract receipt) = _setup();
+        address alice = makeAddr("alice");
+        address operator = makeAddr("operator");
+        address bob = makeAddr("bob");
+
+        manager.mint(receipt, alice, alice, id, amount, "");
+
+        vm.prank(alice);
+        receipt.setApprovalForAll(operator, true);
+
+        vm.prank(operator);
+        receipt.safeTransferFrom(alice, bob, id, amount, "");
+
+        assertEq(manager.lastOperator(), operator, "operator transfer forwards the operator, not the owner");
+    }
+
+    /// The acceptance callback observes the true `msg.sender` (the manager that
+    /// called `managerMint`), NOT the spoofed depositor — the core of the #309
+    /// fix at the callback layer.
+    function testCallbackOperatorIsNotSpoofed(uint256 id, uint256 amount) external {
+        amount = bound(amount, 1, type(uint128).max);
+        (SpyReceiptManager manager, ReceiptContract receipt) = _setup();
+        address depositor = makeAddr("depositor");
+        RecordingReceiver receiver = new RecordingReceiver();
+
+        manager.mint(receipt, depositor, address(receiver), id, amount, "");
+
+        assertEq(receiver.lastOperator(), address(manager), "callback sees the true caller (manager)");
+        assertTrue(receiver.lastOperator() != depositor, "callback operator is NOT the spoofed depositor");
+    }
+
+    /// The operator is scoped to the manager call: after `managerMint` returns,
+    /// a subsequent direct transfer uses the real caller, not a stale operator.
+    function testOperatorResetsAfterManagerCall(uint256 id, uint256 amount) external {
+        amount = bound(amount, 1, type(uint128).max);
+        (SpyReceiptManager manager, ReceiptContract receipt) = _setup();
+        address alice = makeAddr("alice");
+        address bob = makeAddr("bob");
+        address carol = makeAddr("carol");
+
+        // managerMint sets the operator to `alice` then resets it.
+        manager.mint(receipt, alice, bob, id, amount, "");
+
+        // A later direct transfer by bob must record bob, not a stale `alice`.
+        vm.prank(bob);
+        receipt.safeTransferFrom(bob, carol, id, amount, "");
+
+        assertEq(manager.lastOperator(), bob, "operator was reset; direct caller is used");
+    }
+}

--- a/test/src/concrete/receipt/Receipt.operatorIdentity.t.sol
+++ b/test/src/concrete/receipt/Receipt.operatorIdentity.t.sol
@@ -6,6 +6,8 @@ import {Receipt as ReceiptContract} from "src/concrete/receipt/Receipt.sol";
 import {ReceiptFactoryTest} from "test/abstract/ReceiptFactoryTest.sol";
 import {SpyReceiptManager} from "test/concrete/SpyReceiptManager.sol";
 import {RecordingReceiver} from "test/concrete/RecordingReceiver.sol";
+import {ReentrantTransferReceiver} from "test/concrete/ReentrantTransferReceiver.sol";
+import {IERC1155} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155.sol";
 
 /// @title ReceiptOperatorIdentityTest
 /// @notice Validates the operator identity the #309 fix forwards to
@@ -182,5 +184,33 @@ contract ReceiptOperatorIdentityTest is ReceiptFactoryTest {
         receipt.safeBatchTransferFrom(alice, bob, ids, amounts, "");
 
         assertEq(manager.lastOperator(), operator, "batch operator transfer forwards the operator");
+    }
+
+    /// A transfer that RE-ENTERS during a manager call's acceptance callback uses
+    /// its own true caller as the operator, NOT the stale stored operator from
+    /// the outer manager call. The stored operator is cleared before the callback
+    /// fires, so it cannot leak (e.g. a confiscation-style authz bypass) into
+    /// re-entrant transfers.
+    function testReentrantTransferDuringCallbackUsesRealCaller(uint256 id, uint256 amount) external {
+        amount = bound(amount, 1, type(uint128).max);
+        (SpyReceiptManager manager, ReceiptContract receipt) = _setup();
+        address depositor = makeAddr("depositor");
+        address thirdParty = makeAddr("thirdParty");
+
+        ReentrantTransferReceiver receiver =
+            new ReentrantTransferReceiver(IERC1155(address(receipt)), thirdParty, id, amount);
+
+        // managerMint delivers to the receiver, which re-enters during its
+        // acceptance callback to forward its own tokens to `thirdParty`. That
+        // nested transfer is the LAST authz the spy records.
+        manager.mint(receipt, depositor, address(receiver), id, amount, "");
+
+        assertEq(manager.lastFrom(), address(receiver), "nested transfer is from the receiver");
+        assertEq(manager.lastTo(), thirdParty);
+        assertEq(
+            manager.lastOperator(),
+            address(receiver),
+            "re-entrant transfer operator is its true caller, not the stale outer operator"
+        );
     }
 }

--- a/test/src/concrete/receipt/Receipt.operatorIdentity.t.sol
+++ b/test/src/concrete/receipt/Receipt.operatorIdentity.t.sol
@@ -140,6 +140,26 @@ contract ReceiptOperatorIdentityTest is ReceiptFactoryTest {
         assertEq(manager.lastOperator(), bob, "operator was reset; direct caller is used");
     }
 
+    /// Edge case of the consume-once sentinel: `address(0)` doubles as the "no
+    /// operator set" marker, so a manager call that passes `sender == address(0)`
+    /// is indistinguishable from a direct transfer and falls back to forwarding
+    /// the true caller (the manager) as the operator — never `address(0)` itself.
+    /// This is benign (real vaults never pass a zero initiator: `_msgSender()`
+    /// cannot be the zero address), but pinning it guards the sentinel logic
+    /// against silent change.
+    function testManagerCallWithZeroSenderFallsBackToCaller(uint256 id, uint256 amount) external {
+        amount = bound(amount, 1, type(uint128).max);
+        (SpyReceiptManager manager, ReceiptContract receipt) = _setup();
+        address account = makeAddr("account");
+
+        manager.mint(receipt, address(0), account, id, amount, "");
+
+        assertEq(manager.lastOperator(), address(manager), "zero sender falls back to the caller, not address(0)");
+        assertTrue(manager.lastOperator() != address(0), "operator is never the zero sentinel");
+        assertEq(manager.lastFrom(), address(0));
+        assertEq(manager.lastTo(), account);
+    }
+
     /// The batch entrypoint forwards the same operator identity as the single
     /// one: a direct `safeBatchTransferFrom` forwards the real caller.
     function testDirectBatchTransferOperatorIsCaller(uint256 id, uint256 amount) external {

--- a/test/src/concrete/receipt/Receipt.operatorIdentity.t.sol
+++ b/test/src/concrete/receipt/Receipt.operatorIdentity.t.sol
@@ -137,4 +137,50 @@ contract ReceiptOperatorIdentityTest is ReceiptFactoryTest {
 
         assertEq(manager.lastOperator(), bob, "operator was reset; direct caller is used");
     }
+
+    /// The batch entrypoint forwards the same operator identity as the single
+    /// one: a direct `safeBatchTransferFrom` forwards the real caller.
+    function testDirectBatchTransferOperatorIsCaller(uint256 id, uint256 amount) external {
+        amount = bound(amount, 1, type(uint128).max);
+        (SpyReceiptManager manager, ReceiptContract receipt) = _setup();
+        address alice = makeAddr("alice");
+        address bob = makeAddr("bob");
+
+        manager.mint(receipt, alice, alice, id, amount, "");
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = id;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amount;
+
+        vm.prank(alice);
+        receipt.safeBatchTransferFrom(alice, bob, ids, amounts, "");
+
+        assertEq(manager.lastOperator(), alice, "direct batch transfer operator is the caller");
+    }
+
+    /// An approved-operator `safeBatchTransferFrom` forwards the operator, not
+    /// the owner.
+    function testApprovedOperatorBatchTransferOperatorIsOperator(uint256 id, uint256 amount) external {
+        amount = bound(amount, 1, type(uint128).max);
+        (SpyReceiptManager manager, ReceiptContract receipt) = _setup();
+        address alice = makeAddr("alice");
+        address operator = makeAddr("operator");
+        address bob = makeAddr("bob");
+
+        manager.mint(receipt, alice, alice, id, amount, "");
+
+        vm.prank(alice);
+        receipt.setApprovalForAll(operator, true);
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = id;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amount;
+
+        vm.prank(operator);
+        receipt.safeBatchTransferFrom(alice, bob, ids, amounts, "");
+
+        assertEq(manager.lastOperator(), operator, "batch operator transfer forwards the operator");
+    }
 }

--- a/test/src/concrete/receipt/Receipt.operatorLeak.t.sol
+++ b/test/src/concrete/receipt/Receipt.operatorLeak.t.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Receipt as ReceiptContract} from "src/concrete/receipt/Receipt.sol";
+import {ReceiptFactoryTest} from "test/abstract/ReceiptFactoryTest.sol";
+import {FreezeSimReceiptManager, NotPrivileged} from "test/concrete/FreezeSimReceiptManager.sol";
+import {ReentrantLeakReceiver} from "test/concrete/ReentrantLeakReceiver.sol";
+import {IERC1155} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155.sol";
+
+/// @title ReceiptOperatorLeakTest
+/// @notice Proves the SECURITY consequence of the #309 consume-once operator,
+/// not just the operator identity: against a privilege-gated manager (only a
+/// designated handler may move receipts), a transfer that re-enters during an
+/// acceptance callback must NOT inherit the privileged operator of the outer
+/// manager call. The receipt consumes (clears) the stored operator before the
+/// callback fires, so the re-entrant transfer authorizes as the (unprivileged)
+/// receiver and is denied — closing the operator-leak freeze-evasion vector.
+contract ReceiptOperatorLeakTest is ReceiptFactoryTest {
+    function _setup(address privileged) internal returns (FreezeSimReceiptManager manager, ReceiptContract receipt) {
+        manager = new FreezeSimReceiptManager(privileged);
+        receipt = ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(manager))));
+    }
+
+    /// The privileged operator does not leak into a re-entrant transfer. A mint
+    /// runs under the privileged operator and delivers to a malicious receiver;
+    /// the receiver re-enters to forward the tokens to an attacker, but that
+    /// nested transfer authorizes as the receiver (unprivileged) and is denied.
+    function testPrivilegedOperatorDoesNotLeakIntoReentrantTransfer(uint256 id, uint256 amount) external {
+        amount = bound(amount, 1, type(uint128).max);
+        address privileged = makeAddr("privileged");
+        address attacker = makeAddr("attacker");
+        (FreezeSimReceiptManager manager, ReceiptContract receipt) = _setup(privileged);
+
+        ReentrantLeakReceiver receiver = new ReentrantLeakReceiver(IERC1155(address(receipt)), attacker, id, amount);
+
+        // Mint to the receiver under the PRIVILEGED operator (mints are always
+        // allowed). The receiver re-enters during its acceptance callback.
+        manager.mint(receipt, privileged, address(receiver), id, amount, "");
+
+        // The nested transfer was attempted but DENIED — no operator leak, so it
+        // authorized as the unprivileged receiver.
+        assertTrue(receiver.nestedAttempted(), "receiver attempted the re-entrant transfer");
+        assertFalse(receiver.nestedSucceeded(), "re-entrant transfer denied: privileged operator did not leak");
+        assertEq(receipt.balanceOf(attacker, id), 0, "attacker received nothing");
+        assertEq(receipt.balanceOf(address(receiver), id), amount, "receiver kept its receipts");
+
+        // The nested transfer was rejected SPECIFICALLY because its operator was
+        // the receiver, not the privileged handler — i.e. the privileged operator
+        // did not leak. (The manager's `lastOperator` write during the nested
+        // call is rolled back by the revert, so the captured revert data is the
+        // reliable witness.)
+        assertEq(
+            receiver.nestedRevertData(),
+            abi.encodeWithSelector(NotPrivileged.selector, address(receiver)),
+            "nested transfer rejected as the unprivileged receiver operator"
+        );
+    }
+
+    /// Positive control: the SAME peer transfer succeeds when the manager runs it
+    /// under the privileged operator — confirming the denial above is purely the
+    /// operator identity (receiver vs privileged), i.e. the gate works and the
+    /// only thing stopping the attacker is the absence of a leak.
+    function testPrivilegedOperatorCanMoveTheSameReceipts(uint256 id, uint256 amount) external {
+        amount = bound(amount, 1, type(uint128).max);
+        address privileged = makeAddr("privileged");
+        address holder = makeAddr("holder");
+        address attacker = makeAddr("attacker");
+        (FreezeSimReceiptManager manager, ReceiptContract receipt) = _setup(privileged);
+
+        manager.mint(receipt, privileged, holder, id, amount, "");
+
+        // Under the privileged operator the manager moves the holder's receipts.
+        manager.transferFrom(receipt, privileged, holder, attacker, id, amount, "");
+        assertEq(receipt.balanceOf(attacker, id), amount, "privileged operator moved the receipts");
+        assertEq(receipt.balanceOf(holder, id), 0, "holder's receipts moved");
+    }
+
+    /// And an UNPRIVILEGED operator is rejected for the same peer transfer,
+    /// pinning that the gate is keyed on the forwarded operator identity.
+    function testUnprivilegedOperatorIsRejected(uint256 id, uint256 amount) external {
+        amount = bound(amount, 1, type(uint128).max);
+        address privileged = makeAddr("privileged");
+        address intruder = makeAddr("intruder");
+        address holder = makeAddr("holder");
+        address attacker = makeAddr("attacker");
+        (FreezeSimReceiptManager manager, ReceiptContract receipt) = _setup(privileged);
+
+        manager.mint(receipt, privileged, holder, id, amount, "");
+
+        vm.expectRevert(abi.encodeWithSelector(NotPrivileged.selector, intruder));
+        manager.transferFrom(receipt, intruder, holder, attacker, id, amount, "");
+    }
+}

--- a/test/src/concrete/receipt/Receipt.receiptInformation.t.sol
+++ b/test/src/concrete/receipt/Receipt.receiptInformation.t.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Receipt as ReceiptContract} from "src/concrete/receipt/Receipt.sol";
+import {IReceiptV3} from "src/interface/IReceiptV3.sol";
+import {ReceiptFactoryTest} from "test/abstract/ReceiptFactoryTest.sol";
+import {FreeTransferReceiptManager} from "test/concrete/FreeTransferReceiptManager.sol";
+import {SpyReceiptManager} from "test/concrete/SpyReceiptManager.sol";
+
+/// @title ReceiptReceiptInformationTest
+/// @notice Covers the `ReceiptInformation` attribution after the #309 fix. The
+/// auditor's recommendation was to pass the depositor explicitly to
+/// `_receiptInformation` (rather than via a spoofed `_msgSender()`); these tests
+/// isolate three distinct addresses (depositor/recipient/manager, or caller) and
+/// assert the event's `sender` field is the correct one. The existing
+/// `Receipt.t.sol` coverage uses `sender == account`, so it cannot distinguish
+/// which identity the event uses.
+contract ReceiptReceiptInformationTest is ReceiptFactoryTest {
+    /// managerMint attributes `ReceiptInformation` to the explicit depositor
+    /// (`sender`), NOT the recipient (`account`) and NOT the manager/caller.
+    function testManagerMintAttributesInformationToSender(uint256 id, uint256 amount, bytes memory data) external {
+        amount = bound(amount, 1, type(uint128).max);
+        vm.assume(data.length > 0);
+
+        address depositor = makeAddr("depositor");
+        address recipient = makeAddr("recipient");
+
+        FreeTransferReceiptManager manager = new FreeTransferReceiptManager();
+        ReceiptContract receipt =
+            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(manager))));
+
+        vm.expectEmit(true, true, true, true);
+        emit IReceiptV3.ReceiptInformation(depositor, id, data);
+        manager.mint(receipt, depositor, recipient, id, amount, data);
+    }
+
+    /// managerBurn attributes `ReceiptInformation` to the explicit `sender`, NOT
+    /// the holder (`account`) and NOT the manager/caller.
+    function testManagerBurnAttributesInformationToSender(uint256 id, uint256 amount, bytes memory data) external {
+        amount = bound(amount, 1, type(uint128).max);
+        vm.assume(data.length > 0);
+
+        address holder = makeAddr("holder");
+        address burnSender = makeAddr("burnSender");
+
+        SpyReceiptManager manager = new SpyReceiptManager();
+        ReceiptContract receipt =
+            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(manager))));
+
+        manager.mint(receipt, makeAddr("mintSender"), holder, id, amount, "");
+
+        vm.expectEmit(true, true, true, true);
+        emit IReceiptV3.ReceiptInformation(burnSender, id, data);
+        manager.burn(receipt, burnSender, holder, id, amount, data);
+    }
+
+    /// The public `receiptInformation` attributes the event to the real caller —
+    /// `_msgSender()` is no longer overridden, so it is the true `msg.sender`.
+    function testPublicReceiptInformationAttributesToCaller(uint256 id, bytes memory data) external {
+        vm.assume(data.length > 0);
+
+        address alice = makeAddr("alice");
+
+        FreeTransferReceiptManager manager = new FreeTransferReceiptManager();
+        ReceiptContract receipt =
+            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(manager))));
+
+        vm.expectEmit(true, true, true, true);
+        emit IReceiptV3.ReceiptInformation(alice, id, data);
+        vm.prank(alice);
+        receipt.receiptInformation(id, data);
+    }
+}

--- a/test/src/concrete/receipt/Receipt.spoofEndToEnd.t.sol
+++ b/test/src/concrete/receipt/Receipt.spoofEndToEnd.t.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {ERC20PriceOracleReceiptVault} from "src/concrete/vault/ERC20PriceOracleReceiptVault.sol";
+import {ERC20PriceOracleReceiptVaultTest} from "test/abstract/ERC20PriceOracleReceiptVaultTest.sol";
+import {Receipt as ReceiptContract} from "src/concrete/receipt/Receipt.sol";
+import {AtomicDrainReceiver} from "test/concrete/AtomicDrainReceiver.sol";
+import {ReentrantDepositReceiver, IReentrantDepositTarget} from "test/concrete/ReentrantDepositReceiver.sol";
+import {IERC20} from "forge-std-1.16.1/src/interfaces/IERC20.sol";
+import {IERC1155} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155.sol";
+import {IERC1155Errors} from "@openzeppelin-contracts-5.6.1/interfaces/draft-IERC6093.sol";
+import {ReentrancyGuard} from "@openzeppelin-contracts-5.6.1/utils/ReentrancyGuard.sol";
+
+/// @title ReceiptSpoofEndToEndTest
+/// @notice End-to-end #309 regression through a REAL
+/// `ERC20PriceOracleReceiptVault` deposit (not the synthetic test manager the
+/// unit tests use). Confirms the spoof drain is neutralized when it fires from a
+/// genuine vault receipt mint, and that the vault's shared `nonReentrant` guard
+/// forbids re-entering `deposit` from the acceptance callback — the top coverage
+/// item from the #316 reentrancy audit. The vault's base authorizer is permissive
+/// (it only checks the caller is the receipt), so these flows are stopped by OZ's
+/// approval check seeing the true `msg.sender` and by the reentrancy guard — the
+/// exact mechanisms the #309 fix relies on, exercised end-to-end.
+contract ReceiptSpoofEndToEndTest is ERC20PriceOracleReceiptVaultTest {
+    /// The oracle price doubles as the minted receipt id; any non-zero value
+    /// works. `1e18` keeps shares == assets (price is 18-decimal fixed point).
+    uint256 internal constant PRICE = 1e18;
+
+    /// Mocks the asset pull so deposits settle without a real ERC20.
+    function _mockAssetPull() internal {
+        vm.mockCall(address(iAsset), abi.encodeWithSelector(IERC20.transferFrom.selector), abi.encode(true));
+    }
+
+    /// The #309 atomic drain, replayed through a real vault: a depositor deposits
+    /// to a malicious receiver whose acceptance callback tries to drain a victim's
+    /// pre-existing receipts. Post-fix the callback runs as the receiver (not the
+    /// spoofed victim), so OZ's approval check reverts the drain and the whole
+    /// deposit, leaving the victim's holdings intact.
+    function testSpoofDrainThroughRealVaultReverts(uint256 assets) external {
+        assets = bound(assets, 1, type(uint128).max);
+
+        ERC20PriceOracleReceiptVault vault = createVault(iVaultOracle, "Vault", "VLT");
+        ReceiptContract receipt = ReceiptContract(address(vault.receipt()));
+
+        setVaultOraclePrice(PRICE);
+        _mockAssetPull();
+
+        // The victim holds receipts from a legitimate deposit to themselves.
+        address victim = makeAddr("victim");
+        address attacker = makeAddr("attacker");
+        vm.prank(victim);
+        uint256 victimShares = vault.deposit(assets, victim, 0, "");
+        assertEq(receipt.balanceOf(victim, PRICE), victimShares, "victim funded");
+
+        // The attacker deposits to a malicious receiver that, in its acceptance
+        // callback, tries to move the victim's receipts to the attacker. Post-fix
+        // the callback acts as the receiver (unapproved for the victim), so the
+        // drain — and the entire attacker deposit — reverts.
+        AtomicDrainReceiver drainer =
+            new AtomicDrainReceiver(IERC1155(address(receipt)), victim, attacker, PRICE, victimShares);
+        vm.prank(attacker);
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC1155Errors.ERC1155MissingApprovalForAll.selector, address(drainer), victim)
+        );
+        vault.deposit(assets, address(drainer), 0, "");
+
+        // Victim keeps everything; the attacker got nothing.
+        assertEq(receipt.balanceOf(victim, PRICE), victimShares, "victim's receipts untouched");
+        assertEq(receipt.balanceOf(attacker, PRICE), 0, "attacker drained nothing");
+    }
+
+    /// #316 row 7 / coverage item 1: re-entering the vault's `deposit` from inside
+    /// the acceptance callback reverts on the shared `nonReentrant` guard. This is
+    /// the defence-in-depth backstop to the #309 fix — even a callback that did
+    /// observe a spoofed caller could not re-enter a value-moving vault flow.
+    function testReentrantDepositFromCallbackReverts(uint256 assets) external {
+        assets = bound(assets, 1, type(uint128).max);
+
+        ERC20PriceOracleReceiptVault vault = createVault(iVaultOracle, "Vault", "VLT");
+
+        setVaultOraclePrice(PRICE);
+        _mockAssetPull();
+
+        address depositor = makeAddr("depositor");
+        ReentrantDepositReceiver receiver =
+            new ReentrantDepositReceiver(IReentrantDepositTarget(address(vault)), assets);
+
+        // The mint to the receiver fires onERC1155Received, which re-enters
+        // `deposit`; the vault is mid-`_deposit` (nonReentrant), so the nested
+        // call reverts and unwinds the whole outer deposit.
+        vm.prank(depositor);
+        vm.expectRevert(abi.encodeWithSelector(ReentrancyGuard.ReentrancyGuardReentrantCall.selector));
+        vault.deposit(assets, address(receiver), 0, "");
+    }
+}

--- a/test/src/concrete/receipt/Receipt.spoofEscalations.t.sol
+++ b/test/src/concrete/receipt/Receipt.spoofEscalations.t.sol
@@ -3,117 +3,13 @@
 pragma solidity =0.8.25;
 
 import {Receipt as ReceiptContract} from "src/concrete/receipt/Receipt.sol";
-import {IReceiptV3} from "src/interface/IReceiptV3.sol";
-import {IReceiptManagerV2} from "src/interface/IReceiptManagerV2.sol";
 import {ReceiptFactoryTest} from "test/abstract/ReceiptFactoryTest.sol";
-import {IERC1155Receiver} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155Receiver.sol";
+import {FreeTransferReceiptManager} from "test/concrete/FreeTransferReceiptManager.sol";
+import {ApprovalSpoofReceiver} from "test/concrete/ApprovalSpoofReceiver.sol";
+import {AtomicDrainReceiver} from "test/concrete/AtomicDrainReceiver.sol";
+import {BenignReceiver} from "test/concrete/BenignReceiver.sol";
 import {IERC1155} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155.sol";
 import {IERC1155Errors} from "@openzeppelin-contracts-5.6.1/interfaces/draft-IERC6093.sol";
-
-/// @title FreeTransferReceiptManager
-/// @notice Minimal manager that authorizes ALL receipt transfers (no-op
-/// `authorizeReceiptTransfer3`) — the worst case for the #309 spoofing bug,
-/// where receipts are unconditionally transferable and there is no per-transfer
-/// authorization hook to lean on (e.g. any vault inheriting the base
-/// `ReceiptVault` no-op authorizer). `mint` takes an explicit `sender` so tests
-/// can drive the operator directly, the way a vault passes `_msgSender()` (the
-/// depositor) into `managerMint`.
-contract FreeTransferReceiptManager is IReceiptManagerV2 {
-    function authorizeReceiptTransfer3(address, address, address, uint256[] memory, uint256[] memory) external {}
-
-    function mint(IReceiptV3 receipt, address sender, address account, uint256 id, uint256 amount, bytes memory data)
-        external
-    {
-        receipt.managerMint(sender, account, id, amount, data);
-    }
-}
-
-/// Re-enters the receipt during the acceptance callback and tries to grant
-/// `attacker` operator approval. Pre-fix this was spoofed onto the depositor;
-/// post-fix it lands on this contract (the true `msg.sender`).
-contract ApprovalSpoofReceiver is IERC1155Receiver {
-    IERC1155 internal immutable iReceipt;
-    address internal immutable iAttacker;
-
-    constructor(IERC1155 receipt, address attacker) {
-        iReceipt = receipt;
-        iAttacker = attacker;
-    }
-
-    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external returns (bytes4) {
-        iReceipt.setApprovalForAll(iAttacker, true);
-        return IERC1155Receiver.onERC1155Received.selector;
-    }
-
-    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
-        external
-        pure
-        returns (bytes4)
-    {
-        return IERC1155Receiver.onERC1155BatchReceived.selector;
-    }
-
-    function supportsInterface(bytes4) external pure returns (bool) {
-        return true;
-    }
-}
-
-/// Re-enters the receipt during the acceptance callback and tries to drain the
-/// victim's pre-existing receipts. Pre-fix the spoof made `_msgSender()` the
-/// victim so OZ's `from == sender` check passed; post-fix `_msgSender()` is this
-/// contract, so the transfer reverts with `ERC1155MissingApprovalForAll`.
-contract AtomicDrainReceiver is IERC1155Receiver {
-    IERC1155 internal immutable iReceipt;
-    address internal immutable iVictim;
-    address internal immutable iAttacker;
-    uint256 internal immutable iDrainId;
-    uint256 internal immutable iDrainAmount;
-
-    constructor(IERC1155 receipt, address victim, address attacker, uint256 drainId, uint256 drainAmount) {
-        iReceipt = receipt;
-        iVictim = victim;
-        iAttacker = attacker;
-        iDrainId = drainId;
-        iDrainAmount = drainAmount;
-    }
-
-    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external returns (bytes4) {
-        iReceipt.safeTransferFrom(iVictim, iAttacker, iDrainId, iDrainAmount, "");
-        return IERC1155Receiver.onERC1155Received.selector;
-    }
-
-    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
-        external
-        pure
-        returns (bytes4)
-    {
-        return IERC1155Receiver.onERC1155BatchReceived.selector;
-    }
-
-    function supportsInterface(bytes4) external pure returns (bool) {
-        return true;
-    }
-}
-
-/// A benign receiver that does nothing in the callback — models a trusted
-/// recipient such as a pass-through mint/deposit wrapper.
-contract BenignReceiver is IERC1155Receiver {
-    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external pure returns (bytes4) {
-        return IERC1155Receiver.onERC1155Received.selector;
-    }
-
-    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
-        external
-        pure
-        returns (bytes4)
-    {
-        return IERC1155Receiver.onERC1155BatchReceived.selector;
-    }
-
-    function supportsInterface(bytes4) external pure returns (bool) {
-        return true;
-    }
-}
 
 /// @title ReceiptSpoofEscalationsTest
 /// @notice Regression tests for issue #309 against a free-transfer (no-op

--- a/test/src/concrete/receipt/Receipt.spoofEscalations.t.sol
+++ b/test/src/concrete/receipt/Receipt.spoofEscalations.t.sol
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Receipt as ReceiptContract} from "src/concrete/receipt/Receipt.sol";
+import {IReceiptV3} from "src/interface/IReceiptV3.sol";
+import {IReceiptManagerV2} from "src/interface/IReceiptManagerV2.sol";
+import {ReceiptFactoryTest} from "test/abstract/ReceiptFactoryTest.sol";
+import {IERC1155Receiver} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155Receiver.sol";
+import {IERC1155} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155.sol";
+import {IERC1155Errors} from "@openzeppelin-contracts-5.6.1/interfaces/draft-IERC6093.sol";
+
+/// @title FreeTransferReceiptManager
+/// @notice Minimal manager that authorizes ALL receipt transfers (no-op
+/// `authorizeReceiptTransfer3`) — the worst case for this bug, where receipts
+/// are unconditionally transferable and there is no per-transfer authorization
+/// hook to lean on (e.g. any vault inheriting the base `ReceiptVault`
+/// no-op authorizer). `mint` takes an explicit `sender` so tests can drive the
+/// spoofed identity directly, the way a vault passes `_msgSender()` (the
+/// depositor) into `managerMint`.
+contract FreeTransferReceiptManager is IReceiptManagerV2 {
+    function authorizeReceiptTransfer3(address, address, address, uint256[] memory, uint256[] memory) external {}
+
+    function mint(IReceiptV3 receipt, address sender, address account, uint256 id, uint256 amount, bytes memory data)
+        external
+    {
+        receipt.managerMint(sender, account, id, amount, data);
+    }
+}
+
+/// Re-enters the receipt during the acceptance callback and grants `attacker`
+/// operator approval. Spoofed as the depositor, so it lands on the depositor.
+contract ApprovalSpoofReceiver is IERC1155Receiver {
+    IERC1155 internal immutable iReceipt;
+    address internal immutable iAttacker;
+
+    constructor(IERC1155 receipt, address attacker) {
+        iReceipt = receipt;
+        iAttacker = attacker;
+    }
+
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external returns (bytes4) {
+        iReceipt.setApprovalForAll(iAttacker, true);
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return true;
+    }
+}
+
+/// Re-enters the receipt during the acceptance callback and directly drains the
+/// victim's PRE-EXISTING receipts in the same transaction. No approval needed:
+/// `_msgSender()` is spoofed to the victim, so OZ's `from == sender` check
+/// passes for `from = victim`.
+contract AtomicDrainReceiver is IERC1155Receiver {
+    IERC1155 internal immutable iReceipt;
+    address internal immutable iVictim;
+    address internal immutable iAttacker;
+    uint256 internal immutable iDrainId;
+    uint256 internal immutable iDrainAmount;
+
+    constructor(IERC1155 receipt, address victim, address attacker, uint256 drainId, uint256 drainAmount) {
+        iReceipt = receipt;
+        iVictim = victim;
+        iAttacker = attacker;
+        iDrainId = drainId;
+        iDrainAmount = drainAmount;
+    }
+
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external returns (bytes4) {
+        iReceipt.safeTransferFrom(iVictim, iAttacker, iDrainId, iDrainAmount, "");
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return true;
+    }
+}
+
+/// A benign receiver that does nothing in the callback — models a trusted
+/// recipient such as a pass-through mint/deposit wrapper.
+contract BenignReceiver is IERC1155Receiver {
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external pure returns (bytes4) {
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return true;
+    }
+}
+
+/// @title ReceiptSpoofEscalationsTest
+/// @notice Documents the full escalation surface of issue #309 and the
+/// behaviour of the available mitigations, against a free-transfer manager (the
+/// worst case). Escalation tests pass against the vulnerable code; mitigation
+/// tests prove the defences behave as claimed.
+contract ReceiptSpoofEscalationsTest is ReceiptFactoryTest {
+    function _setup() internal returns (FreeTransferReceiptManager manager, ReceiptContract receipt) {
+        manager = new FreeTransferReceiptManager();
+        receipt = ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(manager))));
+    }
+
+    // -------------------------------------------------------------------------
+    // ESCALATIONS (pass against the vulnerable code)
+    // -------------------------------------------------------------------------
+
+    /// E1: a single malicious deposit atomically drains the victim's ENTIRE
+    /// pre-existing receipt balance — in the same transaction, no approval
+    /// required. The spoof makes `_msgSender() == victim`, so the malicious
+    /// receiver's `safeTransferFrom(victim, attacker, ...)` passes OZ's
+    /// `from == sender` check.
+    function testAtomicDrainOfPreExistingReceipts(uint256 legitAmount, uint256 maliciousAmount) external {
+        legitAmount = bound(legitAmount, 1, type(uint128).max);
+        maliciousAmount = bound(maliciousAmount, 1, type(uint128).max);
+
+        (FreeTransferReceiptManager manager, ReceiptContract receipt) = _setup();
+        address victim = makeAddr("victim");
+        address attacker = makeAddr("attacker");
+        uint256 legitId = 1;
+        uint256 maliciousId = 2;
+
+        // Victim legitimately deposits earlier, holding real receipts at its EOA.
+        manager.mint(receipt, victim, victim, legitId, legitAmount, "");
+        assertEq(receipt.balanceOf(victim, legitId), legitAmount);
+
+        AtomicDrainReceiver drainer =
+            new AtomicDrainReceiver(IERC1155(address(receipt)), victim, attacker, legitId, legitAmount);
+
+        // Victim is phished into a deposit naming the drainer as the recipient.
+        manager.mint(receipt, victim, address(drainer), maliciousId, maliciousAmount, "");
+
+        // The victim's pre-existing receipts were drained to the attacker in the
+        // SAME transaction as the malicious deposit.
+        assertEq(receipt.balanceOf(victim, legitId), 0, "victim's existing receipts drained");
+        assertEq(receipt.balanceOf(attacker, legitId), legitAmount, "attacker took the victim's existing receipts");
+    }
+
+    /// E2: the persistent operator approval reaches receipts the victim acquires
+    /// LATER. The malicious deposit grants the approval; a future legitimate
+    /// deposit's receipts are then drainable by the attacker under its own
+    /// identity.
+    function testPersistentApprovalDrainsFutureReceipts(uint256 futureAmount) external {
+        futureAmount = bound(futureAmount, 1, type(uint128).max);
+
+        (FreeTransferReceiptManager manager, ReceiptContract receipt) = _setup();
+        address victim = makeAddr("victim");
+        address attacker = makeAddr("attacker");
+
+        ApprovalSpoofReceiver malicious = new ApprovalSpoofReceiver(IERC1155(address(receipt)), attacker);
+
+        // Malicious deposit grants attacker operator approval, spoofed as victim.
+        manager.mint(receipt, victim, address(malicious), 1, 1, "");
+        assertTrue(receipt.isApprovedForAll(victim, attacker), "approval spoofed onto victim");
+
+        // The victim later acquires NEW receipts in good faith.
+        uint256 futureId = 2;
+        manager.mint(receipt, victim, victim, futureId, futureAmount, "");
+
+        // The attacker drains them later under its OWN identity via the approval.
+        vm.prank(attacker);
+        receipt.safeTransferFrom(victim, attacker, futureId, futureAmount, "");
+
+        assertEq(receipt.balanceOf(victim, futureId), 0, "future receipts drained");
+        assertEq(receipt.balanceOf(attacker, futureId), futureAmount, "attacker took future receipts");
+    }
+
+    // -------------------------------------------------------------------------
+    // MITIGATIONS
+    // -------------------------------------------------------------------------
+
+    /// M1: revocation works mechanically. The victim calls `setApprovalForAll`
+    /// directly — outside any manager call `s.sender == 0`, so `_msgSender()`
+    /// resolves to the real victim — and the approval is cleared. Afterwards the
+    /// attacker can no longer move the victim's receipts.
+    function testVictimCanRevokeApproval(uint256 amount) external {
+        amount = bound(amount, 1, type(uint128).max);
+
+        (FreeTransferReceiptManager manager, ReceiptContract receipt) = _setup();
+        address victim = makeAddr("victim");
+        address attacker = makeAddr("attacker");
+
+        ApprovalSpoofReceiver malicious = new ApprovalSpoofReceiver(IERC1155(address(receipt)), attacker);
+        manager.mint(receipt, victim, address(malicious), 1, 1, "");
+        assertTrue(receipt.isApprovedForAll(victim, attacker));
+
+        // Victim revokes.
+        vm.prank(victim);
+        receipt.setApprovalForAll(attacker, false);
+        assertFalse(receipt.isApprovedForAll(victim, attacker), "approval revoked");
+
+        // Victim acquires receipts; the attacker can no longer take them.
+        uint256 id = 2;
+        manager.mint(receipt, victim, victim, id, amount, "");
+        vm.prank(attacker);
+        vm.expectRevert(abi.encodeWithSelector(IERC1155Errors.ERC1155MissingApprovalForAll.selector, attacker, victim));
+        receipt.safeTransferFrom(victim, attacker, id, amount, "");
+    }
+
+    /// M1 limit: revocation is moot against the atomic drain — by the time the
+    /// victim could revoke, the receipts are already gone (moved in the deposit
+    /// transaction itself).
+    function testRevokeCannotUndoAtomicDrain() external {
+        (FreeTransferReceiptManager manager, ReceiptContract receipt) = _setup();
+        address victim = makeAddr("victim");
+        address attacker = makeAddr("attacker");
+        uint256 legitId = 1;
+        uint256 legitAmount = 1000;
+
+        manager.mint(receipt, victim, victim, legitId, legitAmount, "");
+
+        AtomicDrainReceiver drainer =
+            new AtomicDrainReceiver(IERC1155(address(receipt)), victim, attacker, legitId, legitAmount);
+        manager.mint(receipt, victim, address(drainer), 2, 1, "");
+
+        // Receipts already drained.
+        assertEq(receipt.balanceOf(attacker, legitId), legitAmount);
+
+        // Victim revokes any/all approvals afterwards — too late, nothing returns.
+        vm.prank(victim);
+        receipt.setApprovalForAll(attacker, false);
+        assertEq(receipt.balanceOf(attacker, legitId), legitAmount, "revocation does not recover drained receipts");
+        assertEq(receipt.balanceOf(victim, legitId), 0);
+    }
+
+    /// M2: routing the deposit through a benign receiver (the mint-wrapper
+    /// pattern) gives the attack no foothold: no spoofed approval is granted and
+    /// the victim's pre-existing receipts are untouched. The spoof window only
+    /// opens when the receiver is attacker-controlled.
+    function testBenignReceiverGivesNoFoothold(uint256 legitAmount, uint256 depositAmount) external {
+        legitAmount = bound(legitAmount, 1, type(uint128).max);
+        depositAmount = bound(depositAmount, 1, type(uint128).max);
+
+        (FreeTransferReceiptManager manager, ReceiptContract receipt) = _setup();
+        address victim = makeAddr("victim");
+        address attacker = makeAddr("attacker");
+
+        manager.mint(receipt, victim, victim, 1, legitAmount, "");
+
+        BenignReceiver wrapper = new BenignReceiver();
+        manager.mint(receipt, victim, address(wrapper), 2, depositAmount, "");
+
+        assertFalse(receipt.isApprovedForAll(victim, attacker), "no approval granted");
+        assertEq(receipt.balanceOf(victim, 1), legitAmount, "pre-existing receipts untouched");
+    }
+
+    /// M3: a custody pattern (standing receipts held off the EOA, EOA balance
+    /// ~0) isolates the standing balance. The spoof only grants the victim EOA's
+    /// identity; the atomic drain targets an empty EOA and reverts, so the
+    /// malicious deposit fails entirely and the custodied balance is untouched.
+    /// The attacker also cannot reach the custody address (the spoof is the EOA,
+    /// not the custody contract).
+    function testCustodyIsolatesStandingBalance() external {
+        (FreeTransferReceiptManager manager, ReceiptContract receipt) = _setup();
+        address victim = makeAddr("victim");
+        address custody = makeAddr("custody");
+        address attacker = makeAddr("attacker");
+        uint256 id = 1;
+        uint256 amount = 1000;
+
+        // Victim's standing receipts live in custody; the EOA holds nothing.
+        manager.mint(receipt, custody, custody, id, amount, "");
+        assertEq(receipt.balanceOf(victim, id), 0);
+        assertEq(receipt.balanceOf(custody, id), amount);
+
+        // Phished deposit; the drainer targets the (empty) victim EOA.
+        AtomicDrainReceiver drainer = new AtomicDrainReceiver(IERC1155(address(receipt)), victim, attacker, id, amount);
+        // Draining an empty EOA reverts, taking the whole malicious deposit with
+        // it — the victim loses nothing.
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC1155Errors.ERC1155InsufficientBalance.selector, victim, 0, amount, id)
+        );
+        manager.mint(receipt, victim, address(drainer), 2, 1, "");
+
+        // The custodied balance is untouched.
+        assertEq(receipt.balanceOf(custody, id), amount, "custody balance isolated");
+    }
+}

--- a/test/src/concrete/receipt/Receipt.spoofEscalations.t.sol
+++ b/test/src/concrete/receipt/Receipt.spoofEscalations.t.sol
@@ -7,6 +7,7 @@ import {ReceiptFactoryTest} from "test/abstract/ReceiptFactoryTest.sol";
 import {FreeTransferReceiptManager} from "test/concrete/FreeTransferReceiptManager.sol";
 import {ApprovalSpoofReceiver} from "test/concrete/ApprovalSpoofReceiver.sol";
 import {AtomicDrainReceiver} from "test/concrete/AtomicDrainReceiver.sol";
+import {BatchDrainReceiver} from "test/concrete/BatchDrainReceiver.sol";
 import {BenignReceiver} from "test/concrete/BenignReceiver.sol";
 import {IERC1155} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155.sol";
 import {IERC1155Errors} from "@openzeppelin-contracts-5.6.1/interfaces/draft-IERC6093.sol";
@@ -49,6 +50,30 @@ contract ReceiptSpoofEscalationsTest is ReceiptFactoryTest {
         manager.mint(receipt, victim, address(drainer), 2, 1, "");
 
         // Victim keeps everything; attacker got nothing.
+        assertEq(receipt.balanceOf(victim, legitId), legitAmount, "victim's receipts untouched");
+        assertEq(receipt.balanceOf(attacker, legitId), 0, "attacker drained nothing");
+    }
+
+    /// E1 batch variant (neutralized): the same drain via `safeBatchTransferFrom`
+    /// reverts too, exercising the batch `_update` / acceptance path.
+    function testBatchDrainAttemptReverts(uint256 legitAmount) external {
+        legitAmount = bound(legitAmount, 1, type(uint128).max);
+
+        (FreeTransferReceiptManager manager, ReceiptContract receipt) = _setup();
+        address victim = makeAddr("victim");
+        address attacker = makeAddr("attacker");
+        uint256 legitId = 1;
+
+        manager.mint(receipt, victim, victim, legitId, legitAmount, "");
+
+        BatchDrainReceiver drainer =
+            new BatchDrainReceiver(IERC1155(address(receipt)), victim, attacker, legitId, legitAmount);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC1155Errors.ERC1155MissingApprovalForAll.selector, address(drainer), victim)
+        );
+        manager.mint(receipt, victim, address(drainer), 2, 1, "");
+
         assertEq(receipt.balanceOf(victim, legitId), legitAmount, "victim's receipts untouched");
         assertEq(receipt.balanceOf(attacker, legitId), 0, "attacker drained nothing");
     }

--- a/test/src/concrete/receipt/Receipt.spoofEscalations.t.sol
+++ b/test/src/concrete/receipt/Receipt.spoofEscalations.t.sol
@@ -9,6 +9,7 @@ import {ApprovalSpoofReceiver} from "test/concrete/ApprovalSpoofReceiver.sol";
 import {AtomicDrainReceiver} from "test/concrete/AtomicDrainReceiver.sol";
 import {BatchDrainReceiver} from "test/concrete/BatchDrainReceiver.sol";
 import {BenignReceiver} from "test/concrete/BenignReceiver.sol";
+import {SpyReceiptManager} from "test/concrete/SpyReceiptManager.sol";
 import {IERC1155} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155.sol";
 import {IERC1155Errors} from "@openzeppelin-contracts-5.6.1/interfaces/draft-IERC6093.sol";
 
@@ -159,5 +160,36 @@ contract ReceiptSpoofEscalationsTest is ReceiptFactoryTest {
         vm.prank(operator);
         vm.expectRevert(abi.encodeWithSelector(IERC1155Errors.ERC1155MissingApprovalForAll.selector, operator, victim));
         receipt.safeTransferFrom(victim, operator, id2, amount, "");
+    }
+
+    /// The transfer callback is spoof-safe too, not just the mint callback. A
+    /// `managerTransferFrom` (e.g. confiscation) that delivers a receipt to a
+    /// malicious contract `to` cannot let that contract spoof the `sender`
+    /// (confiscator) or the `from` party: the `setApprovalForAll` it makes in the
+    /// callback lands on itself.
+    function testManagerTransferFromCallbackCannotSpoof(uint256 amount) external {
+        amount = bound(amount, 1, type(uint128).max);
+
+        SpyReceiptManager manager = new SpyReceiptManager();
+        ReceiptContract receipt =
+            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(manager))));
+        address from = makeAddr("from");
+        address confiscator = makeAddr("confiscator");
+        address attacker = makeAddr("attacker");
+        uint256 id = 1;
+
+        manager.mint(receipt, makeAddr("mintSender"), from, id, amount, "");
+
+        ApprovalSpoofReceiver receiver = new ApprovalSpoofReceiver(IERC1155(address(receipt)), attacker);
+
+        // Confiscation-style transfer delivers `from`'s receipt to the malicious
+        // contract; its callback grants `attacker` approval.
+        manager.transferFrom(receipt, confiscator, from, address(receiver), id, amount, "");
+
+        // The approval lands on the receiver (the true caller), not on the
+        // spoofable `from` or `sender` identities.
+        assertFalse(receipt.isApprovedForAll(from, attacker), "from must not be spoofed");
+        assertFalse(receipt.isApprovedForAll(confiscator, attacker), "sender must not be spoofed");
+        assertTrue(receipt.isApprovedForAll(address(receiver), attacker), "approval lands on the true caller");
     }
 }

--- a/test/src/concrete/receipt/Receipt.spoofEscalations.t.sol
+++ b/test/src/concrete/receipt/Receipt.spoofEscalations.t.sol
@@ -9,7 +9,10 @@ import {ApprovalSpoofReceiver} from "test/concrete/ApprovalSpoofReceiver.sol";
 import {AtomicDrainReceiver} from "test/concrete/AtomicDrainReceiver.sol";
 import {BatchDrainReceiver} from "test/concrete/BatchDrainReceiver.sol";
 import {BenignReceiver} from "test/concrete/BenignReceiver.sol";
+import {ManagerForgeReceiver} from "test/concrete/ManagerForgeReceiver.sol";
 import {SpyReceiptManager} from "test/concrete/SpyReceiptManager.sol";
+import {IReceiptV3} from "src/interface/IReceiptV3.sol";
+import {OnlyManager} from "src/error/ErrReceipt.sol";
 import {IERC1155} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155.sol";
 import {IERC1155Errors} from "@openzeppelin-contracts-5.6.1/interfaces/draft-IERC6093.sol";
 
@@ -191,5 +194,28 @@ contract ReceiptSpoofEscalationsTest is ReceiptFactoryTest {
         assertFalse(receipt.isApprovedForAll(from, attacker), "from must not be spoofed");
         assertFalse(receipt.isApprovedForAll(confiscator, attacker), "sender must not be spoofed");
         assertTrue(receipt.isApprovedForAll(address(receiver), attacker), "approval lands on the true caller");
+    }
+
+    /// E3 (neutralized): a malicious receiver cannot forge a manager-only call
+    /// from inside the acceptance callback. The fix leaves `_msgSender()` as the
+    /// true caller, so a re-entrant `managerMint` from the receiver fails
+    /// `_onlyManager` (receiver != manager) and reverts `OnlyManager`, unwinding
+    /// the whole deposit. This closes the "impersonate the manager to mint/burn/
+    /// confiscate during the callback" escalation.
+    function testReentrantManagerForgeRevertsOnlyManager(uint256 id, uint256 amount) external {
+        amount = bound(amount, 1, type(uint128).max);
+
+        (FreeTransferReceiptManager manager, ReceiptContract receipt) = _setup();
+        address depositor = makeAddr("depositor");
+
+        ManagerForgeReceiver forger = new ManagerForgeReceiver(IReceiptV3(address(receipt)), id, amount);
+
+        // The deposit delivers to the forger; its callback tries to mint to
+        // itself as the manager. `_onlyManager` rejects the forged call.
+        vm.expectRevert(abi.encodeWithSelector(OnlyManager.selector));
+        manager.mint(receipt, depositor, address(forger), id, amount, "");
+
+        // Nothing was minted to the forger — the whole operation reverted.
+        assertEq(receipt.balanceOf(address(forger), id), 0, "no receipts minted to the forger");
     }
 }

--- a/test/src/concrete/receipt/Receipt.spoofEscalations.t.sol
+++ b/test/src/concrete/receipt/Receipt.spoofEscalations.t.sol
@@ -12,11 +12,11 @@ import {IERC1155Errors} from "@openzeppelin-contracts-5.6.1/interfaces/draft-IER
 
 /// @title FreeTransferReceiptManager
 /// @notice Minimal manager that authorizes ALL receipt transfers (no-op
-/// `authorizeReceiptTransfer3`) — the worst case for this bug, where receipts
-/// are unconditionally transferable and there is no per-transfer authorization
-/// hook to lean on (e.g. any vault inheriting the base `ReceiptVault`
-/// no-op authorizer). `mint` takes an explicit `sender` so tests can drive the
-/// spoofed identity directly, the way a vault passes `_msgSender()` (the
+/// `authorizeReceiptTransfer3`) — the worst case for the #309 spoofing bug,
+/// where receipts are unconditionally transferable and there is no per-transfer
+/// authorization hook to lean on (e.g. any vault inheriting the base
+/// `ReceiptVault` no-op authorizer). `mint` takes an explicit `sender` so tests
+/// can drive the operator directly, the way a vault passes `_msgSender()` (the
 /// depositor) into `managerMint`.
 contract FreeTransferReceiptManager is IReceiptManagerV2 {
     function authorizeReceiptTransfer3(address, address, address, uint256[] memory, uint256[] memory) external {}
@@ -28,8 +28,9 @@ contract FreeTransferReceiptManager is IReceiptManagerV2 {
     }
 }
 
-/// Re-enters the receipt during the acceptance callback and grants `attacker`
-/// operator approval. Spoofed as the depositor, so it lands on the depositor.
+/// Re-enters the receipt during the acceptance callback and tries to grant
+/// `attacker` operator approval. Pre-fix this was spoofed onto the depositor;
+/// post-fix it lands on this contract (the true `msg.sender`).
 contract ApprovalSpoofReceiver is IERC1155Receiver {
     IERC1155 internal immutable iReceipt;
     address internal immutable iAttacker;
@@ -57,10 +58,10 @@ contract ApprovalSpoofReceiver is IERC1155Receiver {
     }
 }
 
-/// Re-enters the receipt during the acceptance callback and directly drains the
-/// victim's PRE-EXISTING receipts in the same transaction. No approval needed:
-/// `_msgSender()` is spoofed to the victim, so OZ's `from == sender` check
-/// passes for `from = victim`.
+/// Re-enters the receipt during the acceptance callback and tries to drain the
+/// victim's pre-existing receipts. Pre-fix the spoof made `_msgSender()` the
+/// victim so OZ's `from == sender` check passed; post-fix `_msgSender()` is this
+/// contract, so the transfer reverts with `ERC1155MissingApprovalForAll`.
 contract AtomicDrainReceiver is IERC1155Receiver {
     IERC1155 internal immutable iReceipt;
     address internal immutable iVictim;
@@ -115,56 +116,51 @@ contract BenignReceiver is IERC1155Receiver {
 }
 
 /// @title ReceiptSpoofEscalationsTest
-/// @notice Documents the full escalation surface of issue #309 and the
-/// behaviour of the available mitigations, against a free-transfer manager (the
-/// worst case). Escalation tests pass against the vulnerable code; mitigation
-/// tests prove the defences behave as claimed.
+/// @notice Regression tests for issue #309 against a free-transfer (no-op
+/// authorizer) manager — the worst case. They replay every known escalation of
+/// the spoofing attack and assert the fix neutralizes it, and confirm normal
+/// ERC1155 approval/revocation semantics are preserved.
 contract ReceiptSpoofEscalationsTest is ReceiptFactoryTest {
     function _setup() internal returns (FreeTransferReceiptManager manager, ReceiptContract receipt) {
         manager = new FreeTransferReceiptManager();
         receipt = ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(manager))));
     }
 
-    // -------------------------------------------------------------------------
-    // ESCALATIONS (pass against the vulnerable code)
-    // -------------------------------------------------------------------------
-
-    /// E1: a single malicious deposit atomically drains the victim's ENTIRE
-    /// pre-existing receipt balance — in the same transaction, no approval
-    /// required. The spoof makes `_msgSender() == victim`, so the malicious
-    /// receiver's `safeTransferFrom(victim, attacker, ...)` passes OZ's
-    /// `from == sender` check.
-    function testAtomicDrainOfPreExistingReceipts(uint256 legitAmount, uint256 maliciousAmount) external {
+    /// E1 (neutralized): the atomic same-tx drain of the victim's pre-existing
+    /// receipts now reverts. Post-fix `_msgSender()` during the callback is the
+    /// malicious receiver, so its `safeTransferFrom(victim, ...)` fails OZ's
+    /// approval check, reverting the whole malicious deposit. The victim's
+    /// holdings — held at their own EOA, no custody needed — are untouched.
+    function testAtomicDrainAttemptRevertsAndPreservesHoldings(uint256 legitAmount) external {
         legitAmount = bound(legitAmount, 1, type(uint128).max);
-        maliciousAmount = bound(maliciousAmount, 1, type(uint128).max);
 
         (FreeTransferReceiptManager manager, ReceiptContract receipt) = _setup();
         address victim = makeAddr("victim");
         address attacker = makeAddr("attacker");
         uint256 legitId = 1;
-        uint256 maliciousId = 2;
 
-        // Victim legitimately deposits earlier, holding real receipts at its EOA.
         manager.mint(receipt, victim, victim, legitId, legitAmount, "");
         assertEq(receipt.balanceOf(victim, legitId), legitAmount);
 
         AtomicDrainReceiver drainer =
             new AtomicDrainReceiver(IERC1155(address(receipt)), victim, attacker, legitId, legitAmount);
 
-        // Victim is phished into a deposit naming the drainer as the recipient.
-        manager.mint(receipt, victim, address(drainer), maliciousId, maliciousAmount, "");
+        // The malicious deposit reverts because the drainer is not approved to
+        // move the victim's receipts (no spoof).
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC1155Errors.ERC1155MissingApprovalForAll.selector, address(drainer), victim)
+        );
+        manager.mint(receipt, victim, address(drainer), 2, 1, "");
 
-        // The victim's pre-existing receipts were drained to the attacker in the
-        // SAME transaction as the malicious deposit.
-        assertEq(receipt.balanceOf(victim, legitId), 0, "victim's existing receipts drained");
-        assertEq(receipt.balanceOf(attacker, legitId), legitAmount, "attacker took the victim's existing receipts");
+        // Victim keeps everything; attacker got nothing.
+        assertEq(receipt.balanceOf(victim, legitId), legitAmount, "victim's receipts untouched");
+        assertEq(receipt.balanceOf(attacker, legitId), 0, "attacker drained nothing");
     }
 
-    /// E2: the persistent operator approval reaches receipts the victim acquires
-    /// LATER. The malicious deposit grants the approval; a future legitimate
-    /// deposit's receipts are then drainable by the attacker under its own
-    /// identity.
-    function testPersistentApprovalDrainsFutureReceipts(uint256 futureAmount) external {
+    /// E2 (neutralized): no operator approval is spoofed onto the victim, so
+    /// receipts the victim acquires later are NOT reachable by the attacker. The
+    /// approval the malicious callback makes lands on the receiver itself.
+    function testNoSpoofedApprovalSoFutureReceiptsSafe(uint256 futureAmount) external {
         futureAmount = bound(futureAmount, 1, type(uint128).max);
 
         (FreeTransferReceiptManager manager, ReceiptContract receipt) = _setup();
@@ -173,85 +169,24 @@ contract ReceiptSpoofEscalationsTest is ReceiptFactoryTest {
 
         ApprovalSpoofReceiver malicious = new ApprovalSpoofReceiver(IERC1155(address(receipt)), attacker);
 
-        // Malicious deposit grants attacker operator approval, spoofed as victim.
+        // The malicious deposit succeeds (mints to the receiver) but grants the
+        // victim NO approval.
         manager.mint(receipt, victim, address(malicious), 1, 1, "");
-        assertTrue(receipt.isApprovedForAll(victim, attacker), "approval spoofed onto victim");
+        assertFalse(receipt.isApprovedForAll(victim, attacker), "victim not spoofed into approving attacker");
+        assertTrue(receipt.isApprovedForAll(address(malicious), attacker), "approval landed on the true caller");
 
-        // The victim later acquires NEW receipts in good faith.
+        // The victim later acquires receipts; the attacker cannot take them.
         uint256 futureId = 2;
         manager.mint(receipt, victim, victim, futureId, futureAmount, "");
-
-        // The attacker drains them later under its OWN identity via the approval.
-        vm.prank(attacker);
-        receipt.safeTransferFrom(victim, attacker, futureId, futureAmount, "");
-
-        assertEq(receipt.balanceOf(victim, futureId), 0, "future receipts drained");
-        assertEq(receipt.balanceOf(attacker, futureId), futureAmount, "attacker took future receipts");
-    }
-
-    // -------------------------------------------------------------------------
-    // MITIGATIONS
-    // -------------------------------------------------------------------------
-
-    /// M1: revocation works mechanically. The victim calls `setApprovalForAll`
-    /// directly — outside any manager call `s.sender == 0`, so `_msgSender()`
-    /// resolves to the real victim — and the approval is cleared. Afterwards the
-    /// attacker can no longer move the victim's receipts.
-    function testVictimCanRevokeApproval(uint256 amount) external {
-        amount = bound(amount, 1, type(uint128).max);
-
-        (FreeTransferReceiptManager manager, ReceiptContract receipt) = _setup();
-        address victim = makeAddr("victim");
-        address attacker = makeAddr("attacker");
-
-        ApprovalSpoofReceiver malicious = new ApprovalSpoofReceiver(IERC1155(address(receipt)), attacker);
-        manager.mint(receipt, victim, address(malicious), 1, 1, "");
-        assertTrue(receipt.isApprovedForAll(victim, attacker));
-
-        // Victim revokes.
-        vm.prank(victim);
-        receipt.setApprovalForAll(attacker, false);
-        assertFalse(receipt.isApprovedForAll(victim, attacker), "approval revoked");
-
-        // Victim acquires receipts; the attacker can no longer take them.
-        uint256 id = 2;
-        manager.mint(receipt, victim, victim, id, amount, "");
         vm.prank(attacker);
         vm.expectRevert(abi.encodeWithSelector(IERC1155Errors.ERC1155MissingApprovalForAll.selector, attacker, victim));
-        receipt.safeTransferFrom(victim, attacker, id, amount, "");
+        receipt.safeTransferFrom(victim, attacker, futureId, futureAmount, "");
     }
 
-    /// M1 limit: revocation is moot against the atomic drain — by the time the
-    /// victim could revoke, the receipts are already gone (moved in the deposit
-    /// transaction itself).
-    function testRevokeCannotUndoAtomicDrain() external {
-        (FreeTransferReceiptManager manager, ReceiptContract receipt) = _setup();
-        address victim = makeAddr("victim");
-        address attacker = makeAddr("attacker");
-        uint256 legitId = 1;
-        uint256 legitAmount = 1000;
-
-        manager.mint(receipt, victim, victim, legitId, legitAmount, "");
-
-        AtomicDrainReceiver drainer =
-            new AtomicDrainReceiver(IERC1155(address(receipt)), victim, attacker, legitId, legitAmount);
-        manager.mint(receipt, victim, address(drainer), 2, 1, "");
-
-        // Receipts already drained.
-        assertEq(receipt.balanceOf(attacker, legitId), legitAmount);
-
-        // Victim revokes any/all approvals afterwards — too late, nothing returns.
-        vm.prank(victim);
-        receipt.setApprovalForAll(attacker, false);
-        assertEq(receipt.balanceOf(attacker, legitId), legitAmount, "revocation does not recover drained receipts");
-        assertEq(receipt.balanceOf(victim, legitId), 0);
-    }
-
-    /// M2: routing the deposit through a benign receiver (the mint-wrapper
-    /// pattern) gives the attack no foothold: no spoofed approval is granted and
-    /// the victim's pre-existing receipts are untouched. The spoof window only
-    /// opens when the receiver is attacker-controlled.
-    function testBenignReceiverGivesNoFoothold(uint256 legitAmount, uint256 depositAmount) external {
+    /// A deposit routed through a benign receiver (the mint-wrapper pattern) is
+    /// unaffected and grants no approval — sanity that legitimate
+    /// contract-recipient deposits still work.
+    function testBenignReceiverDepositIsUnaffected(uint256 legitAmount, uint256 depositAmount) external {
         legitAmount = bound(legitAmount, 1, type(uint128).max);
         depositAmount = bound(depositAmount, 1, type(uint128).max);
 
@@ -266,37 +201,42 @@ contract ReceiptSpoofEscalationsTest is ReceiptFactoryTest {
 
         assertFalse(receipt.isApprovedForAll(victim, attacker), "no approval granted");
         assertEq(receipt.balanceOf(victim, 1), legitAmount, "pre-existing receipts untouched");
+        assertEq(receipt.balanceOf(address(wrapper), 2), depositAmount, "wrapper received the deposit");
     }
 
-    /// M3: a custody pattern (standing receipts held off the EOA, EOA balance
-    /// ~0) isolates the standing balance. The spoof only grants the victim EOA's
-    /// identity; the atomic drain targets an empty EOA and reverts, so the
-    /// malicious deposit fails entirely and the custodied balance is untouched.
-    /// The attacker also cannot reach the custody address (the spoof is the EOA,
-    /// not the custody contract).
-    function testCustodyIsolatesStandingBalance() external {
+    /// Approval revocation works as standard ERC1155 (the fix does not override
+    /// `_msgSender()`, so approvals are managed by the true caller): a victim can
+    /// grant an operator, the operator can transfer, and after revocation the
+    /// operator can no longer transfer.
+    function testApprovalRevocationWorks(uint256 amount) external {
+        amount = bound(amount, 1, type(uint128).max);
+
         (FreeTransferReceiptManager manager, ReceiptContract receipt) = _setup();
         address victim = makeAddr("victim");
-        address custody = makeAddr("custody");
-        address attacker = makeAddr("attacker");
+        address operator = makeAddr("operator");
         uint256 id = 1;
-        uint256 amount = 1000;
 
-        // Victim's standing receipts live in custody; the EOA holds nothing.
-        manager.mint(receipt, custody, custody, id, amount, "");
-        assertEq(receipt.balanceOf(victim, id), 0);
-        assertEq(receipt.balanceOf(custody, id), amount);
+        manager.mint(receipt, victim, victim, id, amount, "");
 
-        // Phished deposit; the drainer targets the (empty) victim EOA.
-        AtomicDrainReceiver drainer = new AtomicDrainReceiver(IERC1155(address(receipt)), victim, attacker, id, amount);
-        // Draining an empty EOA reverts, taking the whole malicious deposit with
-        // it — the victim loses nothing.
-        vm.expectRevert(
-            abi.encodeWithSelector(IERC1155Errors.ERC1155InsufficientBalance.selector, victim, 0, amount, id)
-        );
-        manager.mint(receipt, victim, address(drainer), 2, 1, "");
+        // Grant.
+        vm.prank(victim);
+        receipt.setApprovalForAll(operator, true);
+        assertTrue(receipt.isApprovedForAll(victim, operator));
 
-        // The custodied balance is untouched.
-        assertEq(receipt.balanceOf(custody, id), amount, "custody balance isolated");
+        // Operator can move the victim's receipts while approved.
+        vm.prank(operator);
+        receipt.safeTransferFrom(victim, operator, id, amount, "");
+        assertEq(receipt.balanceOf(operator, id), amount);
+
+        // Revoke; the operator can no longer move anything.
+        vm.prank(victim);
+        receipt.setApprovalForAll(operator, false);
+        assertFalse(receipt.isApprovedForAll(victim, operator));
+
+        uint256 id2 = 2;
+        manager.mint(receipt, victim, victim, id2, amount, "");
+        vm.prank(operator);
+        vm.expectRevert(abi.encodeWithSelector(IERC1155Errors.ERC1155MissingApprovalForAll.selector, operator, victim));
+        receipt.safeTransferFrom(victim, operator, id2, amount, "");
     }
 }

--- a/test/src/concrete/receipt/Receipt.storageLayout.t.sol
+++ b/test/src/concrete/receipt/Receipt.storageLayout.t.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Receipt as ReceiptContract, RECEIPT_STORAGE_LOCATION} from "src/concrete/receipt/Receipt.sol";
+import {ReceiptFactoryTest} from "test/abstract/ReceiptFactoryTest.sol";
+import {SpyReceiptManager} from "test/concrete/SpyReceiptManager.sol";
+
+/// @title ReceiptStorageLayoutTest
+/// @notice Pins the physical erc7201 storage layout of the `Receipt7201Storage`
+/// struct: `manager` at the base slot and `operator` at base + 1. This is the
+/// upgrade-safety property the #309 fix relies on — it RENAMED the second field
+/// (`sender` -> `operator`) but MUST keep the same slot, order and `address`
+/// type so existing upgradeable deployments (e.g. st0x) are not corrupted. A
+/// future reorder or inserted field would break the consume-once logic and any
+/// proxy reading these slots; these tests fail loudly if that happens. The
+/// existing `Receipt.erc7201.t.sol` only checks the storage LOCATION constant,
+/// not the field offsets.
+contract ReceiptStorageLayoutTest is ReceiptFactoryTest {
+    /// The `operator` field occupies exactly `RECEIPT_STORAGE_LOCATION + 1`.
+    bytes32 internal constant OPERATOR_SLOT = bytes32(uint256(RECEIPT_STORAGE_LOCATION) + 1);
+
+    function _setup() internal returns (SpyReceiptManager manager, ReceiptContract receipt) {
+        manager = new SpyReceiptManager();
+        receipt = ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(manager))));
+    }
+
+    /// `manager` is stored at the base slot (`RECEIPT_STORAGE_LOCATION`).
+    function testManagerFieldAtBaseSlot() external {
+        (SpyReceiptManager manager, ReceiptContract receipt) = _setup();
+        bytes32 raw = vm.load(address(receipt), RECEIPT_STORAGE_LOCATION);
+        assertEq(address(uint160(uint256(raw))), address(manager), "manager occupies the base storage slot");
+    }
+
+    /// `operator` is stored at base + 1 AND the `_update` consume-once reads from
+    /// exactly that slot. Proven without relying on a transient observation: a
+    /// sentinel is planted directly into base + 1, then a direct (non-manager)
+    /// transfer is performed. The fix reads `s.operator` from base + 1, so it
+    /// forwards the planted sentinel as the authorization operator and then
+    /// clears the slot — both observable.
+    function testOperatorFieldAtSlotPlusOneAndConsumed(uint256 id, uint256 amount, address sentinel) external {
+        amount = bound(amount, 1, type(uint128).max);
+        vm.assume(sentinel != address(0));
+
+        (SpyReceiptManager manager, ReceiptContract receipt) = _setup();
+        address alice = makeAddr("alice");
+        address bob = makeAddr("bob");
+
+        // Fund alice via a manager mint (this consumes/clears the operator slot).
+        manager.mint(receipt, alice, alice, id, amount, "");
+        assertEq(vm.load(address(receipt), OPERATOR_SLOT), bytes32(0), "operator slot cleared after manager call");
+
+        // Plant a sentinel operator directly into base + 1.
+        vm.store(address(receipt), OPERATOR_SLOT, bytes32(uint256(uint160(sentinel))));
+
+        // A direct transfer reads the operator from base + 1: it forwards the
+        // sentinel (proving the field offset) rather than the caller.
+        vm.prank(alice);
+        receipt.safeTransferFrom(alice, bob, id, amount, "");
+
+        assertEq(manager.lastOperator(), sentinel, "operator read from base + 1 (forwarded the planted sentinel)");
+        assertEq(vm.load(address(receipt), OPERATOR_SLOT), bytes32(0), "operator slot consumed (cleared) by _update");
+    }
+
+    /// Sanity that the two fields are DISTINCT slots: planting the operator
+    /// sentinel does not disturb the `manager` field at the base slot.
+    function testManagerAndOperatorDoNotAlias(address sentinel) external {
+        vm.assume(sentinel != address(0));
+        (SpyReceiptManager manager, ReceiptContract receipt) = _setup();
+
+        vm.store(address(receipt), OPERATOR_SLOT, bytes32(uint256(uint160(sentinel))));
+
+        bytes32 raw = vm.load(address(receipt), RECEIPT_STORAGE_LOCATION);
+        assertEq(address(uint160(uint256(raw))), address(manager), "manager slot unaffected by operator slot write");
+        assertEq(receipt.manager(), address(manager), "manager() accessor still returns the manager");
+    }
+}

--- a/test/src/concrete/vault/OffchainAssetReceiptVault.confiscateReceiptCertExpired.t.sol
+++ b/test/src/concrete/vault/OffchainAssetReceiptVault.confiscateReceiptCertExpired.t.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {
+    OffchainAssetReceiptVault,
+    CONFISCATE_RECEIPT,
+    DEPOSIT,
+    CERTIFY
+} from "src/concrete/vault/OffchainAssetReceiptVault.sol";
+import {OffchainAssetReceiptVaultTest, Vm} from "test/abstract/OffchainAssetReceiptVaultTest.sol";
+import {Receipt as ReceiptContract} from "src/concrete/receipt/Receipt.sol";
+import {LibUniqueAddressesGenerator} from "../../../lib/LibUniqueAddressesGenerator.sol";
+import {OffchainAssetReceiptVaultAuthorizerV1} from "src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.sol";
+import {CertificationExpired} from "src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.sol";
+
+/// @title ConfiscateReceiptCertExpiredTest
+/// @notice End-to-end regression for the #309 fix's most safety-critical
+/// PRESERVED behavior: confiscation must keep working while the system's
+/// certification is EXPIRED. During expiry the authorizer only permits a receipt
+/// transfer if `hasRole(CONFISCATE_RECEIPT, operator)`, where `operator` is the
+/// identity the receipt forwards from `managerTransferFrom`. The fix forwards the
+/// explicit confiscator (`_msgSender()` of `confiscateReceipt`) as that operator;
+/// a naive fix that forwarded the vault (the receipt's `msg.sender`) instead
+/// would fail the role check and revert `CertificationExpired`, breaking legal
+/// confiscation during a freeze. These tests pin that down through the real
+/// `OffchainAssetReceiptVault`. The existing `confiscateReceipt` suite only ever
+/// runs while certified (default timestamp), so this path was uncovered.
+contract ConfiscateReceiptCertExpiredTest is OffchainAssetReceiptVaultTest {
+    /// Funds `confiscatee` with a receipt while certified, then expires the
+    /// certification. Returns the deployed vault and its receipt. `confiscator`
+    /// holds CONFISCATE_RECEIPT; `agent` (the caller) holds DEPOSIT + CERTIFY.
+    function _setupExpired(address admin, address agent, address confiscator, uint256 assets)
+        internal
+        returns (OffchainAssetReceiptVault vault, ReceiptContract receipt)
+    {
+        vm.warp(1000);
+
+        vm.recordLogs();
+        vault = createVault(admin, "Offchain", "OFF");
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        receipt = getReceipt(logs);
+
+        OffchainAssetReceiptVaultAuthorizerV1 authorizer =
+            OffchainAssetReceiptVaultAuthorizerV1(address(vault.authorizer()));
+        vm.startPrank(admin);
+        authorizer.grantRole(CONFISCATE_RECEIPT, confiscator);
+        authorizer.grantRole(DEPOSIT, agent);
+        authorizer.grantRole(CERTIFY, agent);
+        vm.stopPrank();
+
+        // Certify into the future, deposit while certified (mints receipt id 1 to
+        // the confiscatee), then warp past the certification so the system is
+        // frozen for ordinary transfers.
+        vm.startPrank(agent);
+        vault.certify(2000, false, "");
+        vault.deposit(assets, admin, 0, "");
+        vm.stopPrank();
+
+        vm.warp(3000);
+        assertTrue(vault.isCertificationExpired(), "system should be frozen");
+    }
+
+    /// A confiscator CAN confiscate a receipt during certification expiry: the
+    /// receipt forwards the confiscator as the authorization operator, so the
+    /// CONFISCATE_RECEIPT bypass applies and the receipt moves to the confiscator.
+    function testConfiscateReceiptDuringCertExpirySucceeds(uint256 aliceSeed, uint256 bobSeed, uint256 assets)
+        external
+    {
+        assets = bound(assets, 1, type(uint128).max);
+        (address admin, address confiscator) =
+            LibUniqueAddressesGenerator.generateUniqueAddresses(vm, aliceSeed, bobSeed);
+
+        // The admin is the confiscatee here (receipts were minted to it); the
+        // agent role-holder is also the admin for deposit/certify simplicity.
+        (OffchainAssetReceiptVault vault, ReceiptContract receipt) = _setupExpired(admin, admin, confiscator, assets);
+
+        uint256 id = 1;
+        uint256 confiscateeBefore = receipt.balanceOf(admin, id);
+        assertEq(confiscateeBefore, assets, "confiscatee funded while certified");
+
+        // Confiscation while frozen succeeds — the operator is the confiscator.
+        vm.prank(confiscator);
+        uint256 actual = vault.confiscateReceipt(admin, id, assets, "");
+
+        assertEq(actual, assets, "full balance confiscated");
+        assertEq(receipt.balanceOf(admin, id), 0, "confiscatee drained");
+        assertEq(receipt.balanceOf(confiscator, id), assets, "confiscator received the receipt");
+    }
+
+    /// A caller WITHOUT the CONFISCATE_RECEIPT role cannot confiscate during
+    /// expiry: the receipt forwards that caller as the operator, the bypass does
+    /// not apply, and the transfer reverts `CertificationExpired`. This confirms
+    /// the bypass is keyed on the forwarded operator identity, not granted
+    /// blanket by the fix.
+    function testNonConfiscatorCannotConfiscateDuringCertExpiry(uint256 aliceSeed, uint256 bobSeed, uint256 assets)
+        external
+    {
+        assets = bound(assets, 1, type(uint128).max);
+        (address admin, address confiscator) =
+            LibUniqueAddressesGenerator.generateUniqueAddresses(vm, aliceSeed, bobSeed);
+
+        (OffchainAssetReceiptVault vault,) = _setupExpired(admin, admin, confiscator, assets);
+
+        // `admin` holds DEPOSIT/CERTIFY but NOT CONFISCATE_RECEIPT, so its
+        // confiscation attempt during expiry is rejected by the transfer authz.
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(CertificationExpired.selector, admin, admin));
+        vault.confiscateReceipt(admin, 1, assets, "");
+    }
+}


### PR DESCRIPTION
Fixes the Protofire r2.0 finding **H01** (#309): the `Receipt` contract is vulnerable to identity spoofing through ERC1155 acceptance callbacks.

## The bug

`managerMint`/`managerBurn`/`managerTransferFrom` ran under a `withSender(sender)` modifier that set a stored `sender` and a global `_msgSender()` override returned it for the whole call. During `_mint`, OZ fires `onERC1155Received` on the recipient **before** the call returns — so a malicious `receiver` could re-enter and call `setApprovalForAll(attacker, true)` / `safeTransferFrom(victim, attacker, …)` and have it attributed to the spoofed depositor. A phished depositor could lose operator approval over, and have drained, **all** their receipts (present atomically; future via the lingering approval).

Scope: only reachable when a user routes a mint to attacker-controlled contract code (receiver ≠ self, malicious). The vault always passes the depositor as the spoofed identity, so third parties can't be targeted.

## The fix

Remove the global `_msgSender()` override so inherited ERC1155 functions and their acceptance callbacks observe the **true `msg.sender`** and can no longer be spoofed. A malicious receiver re-entering now acts as itself, so any approval/transfer it makes lands on the receiver, not the depositor.

Per the auditor's "validate the operator identity" caveat, the operator passed to `authorizeReceiptTransfer3` in `_update` is **decoupled** from `_msgSender()`: the manager functions set an explicit `operator` (renamed from `sender`) used **only** for the authz call. This preserves the confiscation-during-certification-expiry bypass (which keys on `hasRole(CONFISCATE_RECEIPT, operator)`) — a naive removal would have passed the vault as operator and broken it.

**Upgrade-safe:** the erc7201 storage struct keeps the same slot/order/type (`IReceiptManagerV2 manager; address operator;`); only the field name changed. Downstream upgradeable consumers (e.g. st0x) can adopt this via implementation upgrade without storage migration.

## Tests

The #309 PoC + escalation suite are flipped from asserting the exploit to asserting it is **neutralized**:
- no operator approval is spoofed onto the victim (it lands on the true caller);
- the atomic same-tx drain reverts (`ERC1155MissingApprovalForAll`);
- future receipts are unreachable;
- standard approval grant/revoke still works.

Full non-fork suite green (349 passed; the only failure is an env-gated Pyth fork test missing `ARBITRUM_RPC_URL`, unrelated). Existing confiscation / authorize-receipt-transfer tests pass unchanged, confirming the operator identity is preserved.

## Downstream

- cyclofinance/cyclo.sol#53 (mint wrapper — Cyclo is immutable/admin-less, can't take this fix)
- cyclofinance/cyclo.site#382 / #383 (docs + recipient invariant; the official site was reviewed and confirmed **not** to expose the vector)
- S01-Issuer/st0x.deploy#200 (upgradeable — should bump to the fixed release and upgrade live deployments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authorization/operator scoping so manager-driven operations correctly attribute the true operator and cannot be spoofed during recipient callbacks, preventing unauthorized approvals, manager-hijack attempts, and transfer escalations.

* **Tests**
  * Added extensive regression and end-to-end tests plus receiver mocks to validate spoofing resistance, reentrancy protections, operator identity, storage-consumption behavior, and receipt-information attribution across mint/burn/transfer flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->