### PR TITLE
Autopublish to Soldeer on merge to main

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -1,0 +1,11 @@
+name: Package Release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release:
+    uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
+    with:
+      soldeer-package: rain-vats
+    secrets: inherit

--- a/.github/workflows/publish-soldeer.yaml
+++ b/.github/workflows/publish-soldeer.yaml
@@ -1,8 +1,0 @@
-name: Publish to Soldeer
-on:
-  push:
-    tags: ["v*"]
-jobs:
-  publish:
-    uses: rainlanguage/rainix/.github/workflows/publish-soldeer.yaml@main
-    secrets: inherit

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,3 +1,7 @@
+[package]
+name = "rain-vats"
+version = "0.1.6"
+
 [profile.default]
 libs = ['dependencies']
 


### PR DESCRIPTION
## What

Wire rain.vats to auto-publish to Soldeer on merge to `main`, instead of the manual `v*` tag flow.

- **`package-release.yaml`** — calls the `rainix-autopublish.yaml` reusable with `soldeer-package: rain-vats` on push to `main`. The reusable reads the version from `foundry.toml`, compares it to the Soldeer registry, and `forge soldeer push`es when they diverge (no auto-bump — the version is set explicitly here).
- **`foundry.toml`** — adds a `[package]` `version` (the source the reusable reads). Set to **`0.1.6`** to publish the #309 `_msgSender` spoof fix (registry is currently `0.1.5`). Foundry tolerates the `[package]` section (emits only an "unknown config section" warning; `forge config`/build/test still parse it).
- **`publish-soldeer.yaml` removed** — the tag-triggered flow is superseded by autopublish.

## Ordering

Depends on **rainlanguage/rainix#215** (soldeer-only support in the reusable — without it the reusable's `Resolve crates` step fails for a crate-less repo). Merge #215 first; then merging this PR triggers the autopublish and publishes `rain-vats~0.1.6`.

## Going forward

Bump `[package].version` in `foundry.toml` in the PR that should ship a new Soldeer release; the merge to `main` publishes it automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)