### PR TITLE
docs: address audit informational findings I01 & I02

### DIFF
--- a/src/concrete/receipt/Receipt.sol
+++ b/src/concrete/receipt/Receipt.sol
@@ -174,6 +174,12 @@ contract Receipt is IReceiptV3, ICloneableV2, ERC1155Upgradeable {
     /// Provides the symbol of the ERC20 asset token that the `ReceiptVault`
     /// managing this `Receipt` is accepting for mints. Can be overridden if the
     /// manager is not going to be a `ReceiptVault`.
+    ///
+    /// Reverts for a manager whose `asset()` is `address(0)` — e.g.
+    /// `OffchainAssetReceiptVault`, whose assets are off-chain — because it calls
+    /// `IERC20Metadata(address(0)).symbol()`. Such managers MUST use a receipt
+    /// implementation that overrides this (so `uri`/metadata does not revert)
+    /// rather than the generic `Receipt`.
     function _vaultAssetSymbol() internal view virtual returns (string memory) {
         Receipt7201Storage storage s = getStorageReceipt();
         return IERC20Metadata(IReceiptVaultV3(payable(address(s.manager))).asset()).symbol();

--- a/src/concrete/vault/OffchainAssetReceiptVault.sol
+++ b/src/concrete/vault/OffchainAssetReceiptVault.sol
@@ -307,7 +307,12 @@ contract OffchainAssetReceiptVault is IAuthorizableV1, ICertifiableV1, IAuthoriz
 
         __ReceiptVault_init(config.receiptVaultConfig);
 
-        // There is no asset, the asset is offchain.
+        // There is no asset, the asset is offchain. Because `asset()` is
+        // therefore `address(0)`, the generic `Receipt` metadata path
+        // (`_vaultAssetSymbol` calls `IERC20Metadata(address(0)).symbol()`)
+        // reverts, so this vault MUST be paired with a receipt implementation
+        // that overrides the asset-symbol metadata rather than the generic
+        // `Receipt`.
         if (config.receiptVaultConfig.asset != address(0)) {
             revert NonZeroAsset();
         }
@@ -633,8 +638,13 @@ contract OffchainAssetReceiptVault is IAuthorizableV1, ICertifiableV1, IAuthoriz
     }
 
     /// Confiscators can confiscate ERC20 vault shares from `confiscatee`.
-    /// Confiscation BYPASSES TRANSFER RESTRICTIONS due to system freeze and
-    /// IGNORES ALLOWANCES set by the confiscatee.
+    /// Confiscation BYPASSES the CERTIFICATION-EXPIRY transfer restriction (the
+    /// authorizer permits a confiscator to move tokens while certification is
+    /// expired) and IGNORES ALLOWANCES set by the confiscatee. It does NOT
+    /// bypass the OWNER FREEZE: confiscation runs through the same
+    /// `ownerFreezeCheckTransaction` as any other transfer, so while an owner
+    /// freeze is active a confiscation reverts unless `from` and `to` are
+    /// allowlisted via `ownerFreezeAlwaysAllowFrom` / `ownerFreezeAlwaysAllowTo`.
     ///
     /// The LIMITATION ON CONFISCATION is that the confiscatee MUST NOT have the
     /// minimum tier for transfers. I.e. confiscation is a two step process.


### PR DESCRIPTION
## What

Address the two **informational** findings from the Protofire rain.vats v0.1.5 r2.0 audit (High: 1 = #309, already fixed; Medium/Low: 0; Informational: 2). Both are documentation findings — NatSpec clarifications, no behaviour change.

### I01 — Owner-freeze precedence over confiscation
The confiscation NatSpec said it "BYPASSES TRANSFER RESTRICTIONS due to system freeze", which reads as bypassing *all* freezes. In fact confiscation only bypasses the **certification-expiry** restriction (the authorizer lets a confiscator move tokens while certification is expired). It does **not** bypass the **owner freeze**: both `confiscateShares` (`_update`) and `confiscateReceipt` (`authorizeReceiptTransfer3`) call `ownerFreezeCheckTransaction(from, to)`, so an active owner freeze reverts a confiscation unless `from`/`to` are allowlisted via `ownerFreezeAlwaysAllowFrom` / `ownerFreezeAlwaysAllowTo`. Clarified on the (shared) confiscation NatSpec. `confiscateReceipt` defers to it ("identical … except per-ID").

### I02 — Generic Receipt metadata for OffchainAssetReceiptVault
`OffchainAssetReceiptVault` requires `asset() == address(0)` (off-chain assets), but the generic `Receipt` builds metadata via `_vaultAssetSymbol()` → `IERC20Metadata(address(0)).symbol()`, which reverts. Documented this at the vault's `NonZeroAsset` requirement and on `Receipt._vaultAssetSymbol()`: such vaults must pair with a receipt implementation that overrides the asset-symbol metadata (e.g. st0x's `StoxReceipt`).

## Notes

- Comment-only; `forge build` succeeds.
- Audit findings were `Status: New` at commit `cb4d925b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)