### PR TITLE
chore: latest rainix + soldeer re-lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         "solc": "solc"
       },
       "locked": {
-        "lastModified": 1780154135,
-        "narHash": "sha256-dzfWTnq+80nLKHkwvbBcEIIJylABaxQShsok8nU0GLM=",
+        "lastModified": 1780287289,
+        "narHash": "sha256-eZ74zj6VwotSmT1kXImwA2yX0el0pZthcgNjg7j/AyQ=",
         "owner": "rainlanguage",
         "repo": "rainix",
-        "rev": "81c6e4e3556abcbad30f51ef46481d01a672adbf",
+        "rev": "f22d4dcaca61717e33eac65e7b09b9a82f604c1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps rainix to latest and re-locks soldeer deps.

- `rainix.url` -> `github:rainlanguage/rainix`, `nix flake update rainix`
- soldeer deps bumped to latest registry versions where behind, then re-locked
- verified via `nix develop` (latest rainix dev shell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)