### PR TITLE
Move inline test helper contracts into dedicated test/concrete/ files

### DIFF
--- a/test/concrete/AlwaysAuthorize.sol
+++ b/test/concrete/AlwaysAuthorize.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {IAuthorizeV1} from "src/concrete/vault/OffchainAssetReceiptVault.sol";
+import {IERC165} from "@openzeppelin-contracts-5.6.1/utils/introspection/IERC165.sol";
+
+contract AlwaysAuthorize is IAuthorizeV1, IERC165 {
+    /// @inheritdoc IERC165
+    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
+        return interfaceId == type(IAuthorizeV1).interfaceId || interfaceId == type(IERC165).interfaceId;
+    }
+
+    /// @inheritdoc IAuthorizeV1
+    function authorize(address, bytes32, bytes memory) external pure override {}
+}

--- a/test/concrete/MutableMetadataReceipt.sol
+++ b/test/concrete/MutableMetadataReceipt.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {ERC20PriceOracleReceipt} from "src/concrete/receipt/ERC20PriceOracleReceipt.sol";
+
+/// This contract is used to test the metadata of the `Receipt` contract.
+/// As all the overridden functions are internal, we need to create a new
+/// contract that inherits from `Receipt` and exposes these functions; we can't
+/// just mock `Receipt`.
+contract MutableMetadataReceipt is ERC20PriceOracleReceipt {
+    string internal sVaultShareSymbol;
+    string internal sVaultAssetSymbol;
+    //forge-lint: disable-next-line(mixed-case-variable)
+    string internal sReceiptSVGURI;
+    string internal sReferenceAssetSymbol;
+    //forge-lint: disable-next-line(mixed-case-variable)
+    string internal sRedeemURL;
+    string internal sBrandName;
+
+    function setVaultShareSymbol(string memory vaultShareSymbol) external {
+        sVaultShareSymbol = vaultShareSymbol;
+    }
+
+    function setVaultAssetSymbol(string memory vaultAssetSymbol) external {
+        sVaultAssetSymbol = vaultAssetSymbol;
+    }
+
+    //forge-lint: disable-next-line(mixed-case-function,mixed-case-variable)
+    function setReceiptSVGURI(string memory receiptSVGURI) external {
+        sReceiptSVGURI = receiptSVGURI;
+    }
+
+    function setReferenceAssetSymbol(string memory referenceAssetSymbol) external {
+        sReferenceAssetSymbol = referenceAssetSymbol;
+    }
+
+    //forge-lint: disable-next-line(mixed-case-function,mixed-case-variable)
+    function setRedeemURL(string memory redeemURL) external {
+        sRedeemURL = redeemURL;
+    }
+
+    function setBrandName(string memory brandName) external {
+        sBrandName = brandName;
+    }
+
+    function _vaultShareSymbol() internal view override returns (string memory) {
+        return sVaultShareSymbol;
+    }
+
+    function _vaultAssetSymbol() internal view override returns (string memory) {
+        return sVaultAssetSymbol;
+    }
+
+    //forge-lint: disable-next-line(mixed-case-function)
+    function _receiptSVGURI() internal view override returns (string memory) {
+        return sReceiptSVGURI;
+    }
+
+    function _referenceAssetSymbol() internal view override returns (string memory) {
+        return sReferenceAssetSymbol;
+    }
+
+    //forge-lint: disable-next-line(mixed-case-function)
+    function _redeemURL() internal view override returns (string memory) {
+        return sRedeemURL;
+    }
+
+    function _brandName() internal view override returns (string memory) {
+        return sBrandName;
+    }
+}

--- a/test/concrete/PriceOracleV2TestImpl.sol
+++ b/test/concrete/PriceOracleV2TestImpl.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {PriceOracleV2} from "src/abstract/PriceOracleV2.sol";
+
+contract PriceOracleV2TestImpl is PriceOracleV2 {
+    uint256 internal sPrice;
+
+    constructor(uint256 price) {
+        sPrice = price;
+    }
+
+    function _price() internal view override returns (uint256) {
+        return sPrice;
+    }
+
+    function setPrice(uint256 price) external {
+        sPrice = price;
+    }
+}

--- a/test/concrete/TestOwnerFreezable.sol
+++ b/test/concrete/TestOwnerFreezable.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {OwnerFreezable} from "src/abstract/OwnerFreezable.sol";
+
+contract TestOwnerFreezable is OwnerFreezable {
+    constructor() {
+        __OwnerFreezable_init();
+        _transferOwnership(msg.sender);
+    }
+}

--- a/test/concrete/TestReceiptManager.sol
+++ b/test/concrete/TestReceiptManager.sol
@@ -4,21 +4,12 @@ pragma solidity =0.8.25;
 
 import {IReceiptV3} from "src/interface/IReceiptV3.sol";
 import {IReceiptManagerV2} from "src/interface/IReceiptManagerV2.sol";
+import {TestReceiptManagerAsset} from "test/concrete/TestReceiptManagerAsset.sol";
 
 /// Thrown when a transfer is not authorized.
 /// @param from The transfer attempted from this address.
 /// @param to The transfer attemped to this address.
 error UnauthorizedTransfer(address from, address to);
-
-contract TestReceiptManagerAsset {
-    function symbol() external pure returns (string memory) {
-        return "TRMAsset";
-    }
-
-    function name() external pure returns (string memory) {
-        return "TestReceiptManagerAsset";
-    }
-}
 
 /// @title TestReceiptManager
 /// @notice TEST contract that can be the manager of an `IReceiptV3` and forward

--- a/test/concrete/TestReceiptManagerAsset.sol
+++ b/test/concrete/TestReceiptManagerAsset.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+/// @title TestReceiptManagerAsset
+/// @notice TEST asset contract that exposes a `symbol` and `name` for use as the
+/// underlying asset of a `TestReceiptManager`. Intended for use only by the test
+/// harness to drive tests.
+contract TestReceiptManagerAsset {
+    function symbol() external pure returns (string memory) {
+        return "TRMAsset";
+    }
+
+    function name() external pure returns (string memory) {
+        return "TestReceiptManagerAsset";
+    }
+}

--- a/test/src/abstract/OwnerFreezable.ownerFreezeUntil.t.sol
+++ b/test/src/abstract/OwnerFreezable.ownerFreezeUntil.t.sol
@@ -3,14 +3,7 @@
 pragma solidity =0.8.25;
 
 import {OwnerFreezableOwnerFreezeUntilTest} from "test/abstract/OwnerFreezableOwnerFreezeUntilTest.t.sol";
-import {OwnerFreezable} from "src/abstract/OwnerFreezable.sol";
-
-contract TestOwnerFreezable is OwnerFreezable {
-    constructor() {
-        __OwnerFreezable_init();
-        _transferOwnership(msg.sender);
-    }
-}
+import {TestOwnerFreezable} from "test/concrete/TestOwnerFreezable.sol";
 
 contract OwnerFreezableTestOwnerFreezeUntil is OwnerFreezableOwnerFreezeUntilTest {
     constructor() {

--- a/test/src/abstract/PriceOracleV2.t.sol
+++ b/test/src/abstract/PriceOracleV2.t.sol
@@ -2,24 +2,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {PriceOracleV2} from "src/abstract/PriceOracleV2.sol";
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-
-contract PriceOracleV2TestImpl is PriceOracleV2 {
-    uint256 internal sPrice;
-
-    constructor(uint256 price) {
-        sPrice = price;
-    }
-
-    function _price() internal view override returns (uint256) {
-        return sPrice;
-    }
-
-    function setPrice(uint256 price) external {
-        sPrice = price;
-    }
-}
+import {PriceOracleV2TestImpl} from "test/concrete/PriceOracleV2TestImpl.sol";
 
 contract PriceOracleV2Test is Test {
     address constant ALICE = address(uint160(uint256(keccak256("ALICE"))));

--- a/test/src/concrete/receipt/ERC20PriceOracleReceipt.metadata.t.sol
+++ b/test/src/concrete/receipt/ERC20PriceOracleReceipt.metadata.t.sol
@@ -19,73 +19,7 @@ import {
     CMASK_BACKSLASH
 } from "rain-string-0.2.0/src/lib/parse/LibParseCMask.sol";
 import {IERC20Metadata} from "@openzeppelin-contracts-5.6.1/token/ERC20/extensions/IERC20Metadata.sol";
-
-/// This contract is used to test the metadata of the `Receipt` contract.
-/// As all the overridden functions are internal, we need to create a new
-/// contract that inherits from `Receipt` and exposes these functions; we can't
-/// just mock `Receipt`.
-contract MutableMetadataReceipt is ERC20PriceOracleReceipt {
-    string internal sVaultShareSymbol;
-    string internal sVaultAssetSymbol;
-    //forge-lint: disable-next-line(mixed-case-variable)
-    string internal sReceiptSVGURI;
-    string internal sReferenceAssetSymbol;
-    //forge-lint: disable-next-line(mixed-case-variable)
-    string internal sRedeemURL;
-    string internal sBrandName;
-
-    function setVaultShareSymbol(string memory vaultShareSymbol) external {
-        sVaultShareSymbol = vaultShareSymbol;
-    }
-
-    function setVaultAssetSymbol(string memory vaultAssetSymbol) external {
-        sVaultAssetSymbol = vaultAssetSymbol;
-    }
-
-    //forge-lint: disable-next-line(mixed-case-function,mixed-case-variable)
-    function setReceiptSVGURI(string memory receiptSVGURI) external {
-        sReceiptSVGURI = receiptSVGURI;
-    }
-
-    function setReferenceAssetSymbol(string memory referenceAssetSymbol) external {
-        sReferenceAssetSymbol = referenceAssetSymbol;
-    }
-
-    //forge-lint: disable-next-line(mixed-case-function,mixed-case-variable)
-    function setRedeemURL(string memory redeemURL) external {
-        sRedeemURL = redeemURL;
-    }
-
-    function setBrandName(string memory brandName) external {
-        sBrandName = brandName;
-    }
-
-    function _vaultShareSymbol() internal view override returns (string memory) {
-        return sVaultShareSymbol;
-    }
-
-    function _vaultAssetSymbol() internal view override returns (string memory) {
-        return sVaultAssetSymbol;
-    }
-
-    //forge-lint: disable-next-line(mixed-case-function)
-    function _receiptSVGURI() internal view override returns (string memory) {
-        return sReceiptSVGURI;
-    }
-
-    function _referenceAssetSymbol() internal view override returns (string memory) {
-        return sReferenceAssetSymbol;
-    }
-
-    //forge-lint: disable-next-line(mixed-case-function)
-    function _redeemURL() internal view override returns (string memory) {
-        return sRedeemURL;
-    }
-
-    function _brandName() internal view override returns (string memory) {
-        return sBrandName;
-    }
-}
+import {MutableMetadataReceipt} from "test/concrete/MutableMetadataReceipt.sol";
 
 contract ERC20PriceOracleReceiptMetadataTest is ReceiptFactoryTest {
     function testReceiptURIZeroError() external {

--- a/test/src/concrete/vault/OffchainAssetReceiptVault.authorize.t.sol
+++ b/test/src/concrete/vault/OffchainAssetReceiptVault.authorize.t.sol
@@ -12,18 +12,8 @@ import {
     CertifyStateChange
 } from "src/concrete/vault/OffchainAssetReceiptVault.sol";
 import {LibExtrospectERC1167Proxy} from "rain-extrospection-0.1.1/src/lib/LibExtrospectERC1167Proxy.sol";
-import {IERC165} from "@openzeppelin-contracts-5.6.1/utils/introspection/IERC165.sol";
 import {OwnableUpgradeable as Ownable} from "@openzeppelin-contracts-upgradeable-5.6.1/access/OwnableUpgradeable.sol";
-
-contract AlwaysAuthorize is IAuthorizeV1, IERC165 {
-    /// @inheritdoc IERC165
-    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
-        return interfaceId == type(IAuthorizeV1).interfaceId || interfaceId == type(IERC165).interfaceId;
-    }
-
-    /// @inheritdoc IAuthorizeV1
-    function authorize(address, bytes32, bytes memory) external pure override {}
-}
+import {AlwaysAuthorize} from "test/concrete/AlwaysAuthorize.sol";
 
 contract OffchainAssetReceiptVaultAuthorizeTest is OffchainAssetReceiptVaultTest {
     /// Test that authorize contract is as initialized.


### PR DESCRIPTION
## What

Resolves the pre-existing convention violations found by the repo-wide audit in #314: four `.t.sol` files each declared a helper contract inline alongside their test contract. This extracts each helper into its own `test/concrete/<ContractName>.sol` (one contract per file, named after the contract) and imports it back into the `.t.sol`.

| Helper | Moved from | Moved to |
|---|---|---|
| `AlwaysAuthorize` | `test/src/concrete/vault/OffchainAssetReceiptVault.authorize.t.sol` | `test/concrete/AlwaysAuthorize.sol` |
| `MutableMetadataReceipt` | `test/src/concrete/receipt/ERC20PriceOracleReceipt.metadata.t.sol` | `test/concrete/MutableMetadataReceipt.sol` |
| `PriceOracleV2TestImpl` | `test/src/abstract/PriceOracleV2.t.sol` | `test/concrete/PriceOracleV2TestImpl.sol` |
| `TestOwnerFreezable` | `test/src/abstract/OwnerFreezable.ownerFreezeUntil.t.sol` | `test/concrete/TestOwnerFreezable.sol` |

## How

Pure relocation, no logic change:

- Each moved contract body is **byte-identical** to its origin (verified by diff).
- The new files add only the SPDX header / pragma / imports each contract needs.
- The corresponding `.t.sol` now imports the helper and declares only its own test contract; imports that were used solely by the inline helper were removed.
- No test logic touched.

After this change, no `test/**/*.t.sol` declares more than one contract.

## Verify

- `forge build` clean (only pre-existing `missing-zero-check` lint warnings on the unrelated `#309` helpers).
- `forge test` for the four affected suites: 37 passed, 0 failed, 0 skipped.

Note: the second checkbox in #314 (a CI/lint guard against regressions) is intentionally out of scope here — this PR only performs the relocation. Happy to follow up with the guard separately.

Closes #314