### PR TITLE
chore: bump rain-factory 0.1.1 → 0.1.5 (publishes rain-vats 0.1.7); migrate to next-version publish convention

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rain-vats"
-version = "0.1.6"
+version = "0.1.7"
 
 [profile.default]
 libs = ['dependencies']
@@ -27,7 +27,7 @@ forge-std = "1.16.1"
 "@openzeppelin-contracts" = "5.6.1"
 "@openzeppelin-contracts-upgradeable" = "5.6.1"
 "rain-extrospection" = "0.1.1"
-"rain-factory" = "0.1.1"
+"rain-factory" = "0.1.5"
 "rain-flare" = "0.1.2"
 "rain-math-fixedpoint" = "0.2.0"
 "rain-math-float" = "0.1.1"

--- a/remappings.txt
+++ b/remappings.txt
@@ -3,6 +3,7 @@
 forge-std-1.16.1/=dependencies/forge-std-1.16.1/
 rain-extrospection-0.1.1/=dependencies/rain-extrospection-0.1.1/
 rain-factory-0.1.1/=dependencies/rain-factory-0.1.1/
+rain-factory-0.1.5/=dependencies/rain-factory-0.1.5/
 rain-flare-0.1.2/=dependencies/rain-flare-0.1.2/
 rain-math-fixedpoint-0.2.0/=dependencies/rain-math-fixedpoint-0.2.0/
 rain-math-float-0.1.1/=dependencies/rain-math-float-0.1.1/

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -28,10 +28,10 @@ integrity = "aa7366cac7d9c7610350a49b8126c667d83812a974539e79ccd38a5577cd626b"
 
 [[dependencies]]
 name = "rain-factory"
-version = "0.1.1"
-url = "https://soldeer-revisions.s3.amazonaws.com/rain-factory/0_1_1_20-05-2026_13:02:17_rain.zip"
-checksum = "6b02e2b87983e196bc88cb8fb802a2720b252783429567864cd13336167c369d"
-integrity = "be6a3343d0ea247d8b495b584cd21c3bf64f0a1396ca21aaa8ce31715df29842"
+version = "0.1.5"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-factory/0_1_5_12-07-2026_14:01:52_rain.zip"
+checksum = "31f5ac857d16b8dad27eec11218a338ce13721114b0514b05e500b14edf8ce80"
+integrity = "6e6eb9dc5174068e39d6ac80981210723088dde56c9cb0925ffe657ba3154cbc"
 
 [[dependencies]]
 name = "rain-flare"

--- a/src/abstract/ReceiptVault.sol
+++ b/src/abstract/ReceiptVault.sol
@@ -15,7 +15,7 @@ import {
 } from "rain-math-fixedpoint-0.2.0/src/lib/LibFixedPointDecimalArithmeticOpenZeppelin.sol";
 // Export ICLONEABLE_V2_SUCCESS for concrete implementations.
 // forge-lint: disable-next-line(unused-import)
-import {ICloneableV2, ICLONEABLE_V2_SUCCESS} from "rain-factory-0.1.1/src/interface/ICloneableV2.sol";
+import {ICloneableV2, ICLONEABLE_V2_SUCCESS} from "rain-factory-0.1.5/src/interface/ICloneableV2.sol";
 import {Address} from "@openzeppelin-contracts-5.6.1/utils/Address.sol";
 import {
     InvalidId,

--- a/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.sol
+++ b/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.sol
@@ -6,7 +6,7 @@ import {IAuthorizeV1, Unauthorized} from "../../interface/IAuthorizeV1.sol";
 
 import {AccessControlUpgradeable} from "@openzeppelin-contracts-upgradeable-5.6.1/access/AccessControlUpgradeable.sol";
 import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
-import {ICloneableV2, ICLONEABLE_V2_SUCCESS} from "rain-factory-0.1.1/src/interface/ICloneableV2.sol";
+import {ICloneableV2, ICLONEABLE_V2_SUCCESS} from "rain-factory-0.1.5/src/interface/ICloneableV2.sol";
 import {
     CONFISCATE_RECEIPT,
     CONFISCATE_SHARES,

--- a/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.sol
+++ b/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.sol
@@ -4,7 +4,7 @@ pragma solidity =0.8.25;
 
 import {IAuthorizeV1, Unauthorized} from "../../interface/IAuthorizeV1.sol";
 
-import {ICloneableV2, ICLONEABLE_V2_SUCCESS} from "rain-factory-0.1.1/src/interface/ICloneableV2.sol";
+import {ICloneableV2, ICLONEABLE_V2_SUCCESS} from "rain-factory-0.1.5/src/interface/ICloneableV2.sol";
 import {SafeERC20} from "@openzeppelin-contracts-5.6.1/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin-contracts-5.6.1/token/ERC20/IERC20.sol";
 import {DEPOSIT, DepositStateChange} from "../vault/OffchainAssetReceiptVault.sol";

--- a/src/concrete/receipt/Receipt.sol
+++ b/src/concrete/receipt/Receipt.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {ICloneableV2, ICLONEABLE_V2_SUCCESS} from "rain-factory-0.1.1/src/interface/ICloneableV2.sol";
+import {ICloneableV2, ICLONEABLE_V2_SUCCESS} from "rain-factory-0.1.5/src/interface/ICloneableV2.sol";
 
 import {IReceiptManagerV2} from "../../interface/IReceiptManagerV2.sol";
 import {IReceiptV3} from "../../interface/IReceiptV3.sol";

--- a/test/abstract/ReceiptFactoryTest.sol
+++ b/test/abstract/ReceiptFactoryTest.sol
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity ^0.8.25;
 
-import {ICloneableFactoryV2} from "rain-factory-0.1.1/src/interface/ICloneableFactoryV2.sol";
-import {CloneFactory} from "rain-factory-0.1.1/src/concrete/CloneFactory.sol";
+import {ICloneableFactoryV3} from "rain-factory-0.1.5/src/interface/ICloneableFactoryV3.sol";
+import {CloneFactory} from "rain-factory-0.1.5/src/concrete/CloneFactory.sol";
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {Receipt as ReceiptContract} from "../../src/concrete/receipt/Receipt.sol";
 import {ERC20PriceOracleReceipt} from "../../src/concrete/receipt/ERC20PriceOracleReceipt.sol";
@@ -24,14 +24,24 @@ contract ReceiptFactoryTest is Test {
         string name;
     }
 
-    ICloneableFactoryV2 internal immutable iFactory;
+    ICloneableFactoryV3 internal immutable iFactory;
     ReceiptContract internal immutable iReceiptImplementation;
     ERC20PriceOracleReceipt internal immutable iErc20PriceOracleReceiptImplementation;
+
+    /// A fresh salt for each shared-factory clone, so repeated deterministic
+    /// clones of the same implementation never collide on their CREATE2 address.
+    uint256 private sCloneSalt;
 
     constructor() {
         iFactory = new CloneFactory();
         iReceiptImplementation = new ReceiptContract();
         iErc20PriceOracleReceiptImplementation = new ERC20PriceOracleReceipt();
+    }
+
+    /// Deterministically clones and initializes `implementation` via the shared
+    /// factory with a fresh salt, so sibling clones in a test never collide.
+    function cloneReceipt(address implementation, bytes memory data) internal returns (address) {
+        return iFactory.cloneDeterministic(implementation, data, bytes32(sCloneSalt++));
     }
 
     function decodeMetadataURI(string memory uri) internal pure returns (Metadata memory) {

--- a/test/concrete/ConcreteReceiptVault.sol
+++ b/test/concrete/ConcreteReceiptVault.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.25;
 
 import {ReceiptVault, ReceiptVaultConfigV2} from "../../src/abstract/ReceiptVault.sol";
-import {ICLONEABLE_V2_SUCCESS} from "rain-factory-0.1.1/src/interface/ICloneableV2.sol";
+import {ICLONEABLE_V2_SUCCESS} from "rain-factory-0.1.5/src/interface/ICloneableV2.sol";
 
 contract ConcreteReceiptVault is ReceiptVault {
     function initialize(bytes calldata data) external virtual override initializer returns (bytes32) {

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.authorize.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.authorize.t.sol
@@ -16,7 +16,7 @@ import {
     WITHDRAW,
     CertificationExpired
 } from "src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.sol";
-import {CloneFactory} from "rain-factory-0.1.1/src/concrete/CloneFactory.sol";
+import {CloneFactory} from "rain-factory-0.1.5/src/concrete/CloneFactory.sol";
 import {TransferSharesStateChange, TransferReceiptStateChange} from "src/concrete/vault/OffchainAssetReceiptVault.sol";
 
 contract OffchainAssetReceiptVaultAuthorizerV1AuthorizeTest is OffchainAssetReceiptVaultAuthorizerV1Test {
@@ -28,7 +28,7 @@ contract OffchainAssetReceiptVaultAuthorizerV1AuthorizeTest is OffchainAssetRece
 
         CloneFactory factory = new CloneFactory();
         return
-            OffchainAssetReceiptVaultAuthorizerV1(factory.clone(address(authorizerImplementation), abi.encode(config)));
+            OffchainAssetReceiptVaultAuthorizerV1(factory.cloneDeterministic(address(authorizerImplementation), abi.encode(config), bytes32(0)));
     }
 
     function testOffchainAssetReceiptVaultAuthorizerV1AuthorizeUnauthorized(

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.authorize.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.authorize.t.sol
@@ -27,8 +27,9 @@ contract OffchainAssetReceiptVaultAuthorizerV1AuthorizeTest is OffchainAssetRece
             OffchainAssetReceiptVaultAuthorizerV1Config({initialAdmin: initialAdmin});
 
         CloneFactory factory = new CloneFactory();
-        return
-            OffchainAssetReceiptVaultAuthorizerV1(factory.cloneDeterministic(address(authorizerImplementation), abi.encode(config), bytes32(0)));
+        return OffchainAssetReceiptVaultAuthorizerV1(
+            factory.cloneDeterministic(address(authorizerImplementation), abi.encode(config), bytes32(0))
+        );
     }
 
     function testOffchainAssetReceiptVaultAuthorizerV1AuthorizeUnauthorized(

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.construct.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.construct.t.sol
@@ -19,7 +19,7 @@ import {
     WITHDRAW,
     ZeroInitialAdmin
 } from "src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.sol";
-import {CloneFactory} from "rain-factory-0.1.1/src/concrete/CloneFactory.sol";
+import {CloneFactory} from "rain-factory-0.1.5/src/concrete/CloneFactory.sol";
 import {Initializable} from "@openzeppelin-contracts-upgradeable-5.6.1/proxy/utils/Initializable.sol";
 
 contract OffchainAssetReceiptVaultAuthorizerV1ConstructTest is Test {
@@ -53,7 +53,7 @@ contract OffchainAssetReceiptVaultAuthorizerV1ConstructTest is Test {
         CloneFactory factory = new CloneFactory();
 
         OffchainAssetReceiptVaultAuthorizerV1 authorizer =
-            OffchainAssetReceiptVaultAuthorizerV1(factory.clone(address(authorizerImplementation), initData));
+            OffchainAssetReceiptVaultAuthorizerV1(factory.cloneDeterministic(address(authorizerImplementation), initData, bytes32(0)));
 
         vm.assertTrue(authorizer.hasRole(CERTIFY_ADMIN, initialAdmin));
         vm.assertTrue(authorizer.hasRole(CONFISCATE_SHARES_ADMIN, initialAdmin));
@@ -77,6 +77,6 @@ contract OffchainAssetReceiptVaultAuthorizerV1ConstructTest is Test {
         CloneFactory factory = new CloneFactory();
 
         vm.expectRevert(ZeroInitialAdmin.selector);
-        OffchainAssetReceiptVaultAuthorizerV1(factory.clone(address(authorizerImplementation), initData));
+        OffchainAssetReceiptVaultAuthorizerV1(factory.cloneDeterministic(address(authorizerImplementation), initData, bytes32(0)));
     }
 }

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.construct.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.construct.t.sol
@@ -52,8 +52,9 @@ contract OffchainAssetReceiptVaultAuthorizerV1ConstructTest is Test {
 
         CloneFactory factory = new CloneFactory();
 
-        OffchainAssetReceiptVaultAuthorizerV1 authorizer =
-            OffchainAssetReceiptVaultAuthorizerV1(factory.cloneDeterministic(address(authorizerImplementation), initData, bytes32(0)));
+        OffchainAssetReceiptVaultAuthorizerV1 authorizer = OffchainAssetReceiptVaultAuthorizerV1(
+            factory.cloneDeterministic(address(authorizerImplementation), initData, bytes32(0))
+        );
 
         vm.assertTrue(authorizer.hasRole(CERTIFY_ADMIN, initialAdmin));
         vm.assertTrue(authorizer.hasRole(CONFISCATE_SHARES_ADMIN, initialAdmin));
@@ -77,6 +78,8 @@ contract OffchainAssetReceiptVaultAuthorizerV1ConstructTest is Test {
         CloneFactory factory = new CloneFactory();
 
         vm.expectRevert(ZeroInitialAdmin.selector);
-        OffchainAssetReceiptVaultAuthorizerV1(factory.cloneDeterministic(address(authorizerImplementation), initData, bytes32(0)));
+        OffchainAssetReceiptVaultAuthorizerV1(
+            factory.cloneDeterministic(address(authorizerImplementation), initData, bytes32(0))
+        );
     }
 }

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.ierc165.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.ierc165.t.sol
@@ -7,7 +7,7 @@ import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {IERC165} from "@openzeppelin-contracts-5.6.1/utils/introspection/IERC165.sol";
 import {OffchainAssetReceiptVaultAuthorizerV1} from "src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.sol";
 import {IAuthorizeV1} from "src/interface/IAuthorizeV1.sol";
-import {ICloneableV2} from "rain-factory-0.1.1/src/interface/ICloneableV2.sol";
+import {ICloneableV2} from "rain-factory-0.1.5/src/interface/ICloneableV2.sol";
 import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
 
 contract OffchainAssetReceiptVaultAuthorizerV1IERC165Test is Test {

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.authorize.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.authorize.t.sol
@@ -48,7 +48,9 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1IERC165Test is Offchain
         vm.mockCall(
             paymentToken, abi.encodeWithSelector(IERC20Metadata.decimals.selector), abi.encode(paymentTokenDecimals)
         );
-        return OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.cloneDeterministic(address(implementation), initData, bytes32(0)));
+        return OffchainAssetReceiptVaultPaymentMintAuthorizerV1(
+            factory.cloneDeterministic(address(implementation), initData, bytes32(0))
+        );
     }
 
     function testOffchainAssetReceiptVaultPaymentMintAuthorizerV1UnauthorizedCaller(

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.authorize.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.authorize.t.sol
@@ -18,7 +18,7 @@ import {
     WITHDRAW_ADMIN,
     WITHDRAW
 } from "src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.sol";
-import {CloneFactory} from "rain-factory-0.1.1/src/concrete/CloneFactory.sol";
+import {CloneFactory} from "rain-factory-0.1.5/src/concrete/CloneFactory.sol";
 import {IERC20Metadata} from "@openzeppelin-contracts-5.6.1/token/ERC20/extensions/IERC20Metadata.sol";
 import {VerifyAlwaysApproved} from "rain-verify-interface-0.1.0/src/concrete/VerifyAlwaysApproved.sol";
 import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
@@ -48,7 +48,7 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1IERC165Test is Offchain
         vm.mockCall(
             paymentToken, abi.encodeWithSelector(IERC20Metadata.decimals.selector), abi.encode(paymentTokenDecimals)
         );
-        return OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.clone(address(implementation), initData));
+        return OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.cloneDeterministic(address(implementation), initData, bytes32(0)));
     }
 
     function testOffchainAssetReceiptVaultPaymentMintAuthorizerV1UnauthorizedCaller(

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.construct.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.construct.t.sol
@@ -13,9 +13,9 @@ import {
     ZeroPaymentToken,
     ZeroMaxSharesSupply
 } from "src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.sol";
-import {CloneFactory} from "rain-factory-0.1.1/src/concrete/CloneFactory.sol";
+import {CloneFactory} from "rain-factory-0.1.5/src/concrete/CloneFactory.sol";
 import {IERC20Metadata} from "@openzeppelin-contracts-5.6.1/token/ERC20/extensions/IERC20Metadata.sol";
-import {ICloneableV2} from "rain-factory-0.1.1/src/interface/ICloneableV2.sol";
+import {ICloneableV2} from "rain-factory-0.1.5/src/interface/ICloneableV2.sol";
 import {IAuthorizeV1} from "src/interface/IAuthorizeV1.sol";
 import {IERC165} from "@openzeppelin-contracts-5.6.1/utils/introspection/IERC165.sol";
 import {
@@ -70,7 +70,7 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1ConstructTest is Test {
             })
         );
         vm.expectRevert(ZeroReceiptVault.selector);
-        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.clone(address(implementation), initData));
+        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.cloneDeterministic(address(implementation), initData, bytes32(0)));
     }
 
     function testOffchainAssetReceiptVaultPaymentMintAuthorizerV1ZeroInitialOwner(address receiptVault) external {
@@ -90,7 +90,7 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1ConstructTest is Test {
             })
         );
         vm.expectRevert(ZeroInitialOwner.selector);
-        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.clone(address(implementation), initData));
+        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.cloneDeterministic(address(implementation), initData, bytes32(0)));
     }
 
     function testOffchainAssetReceiptVaultPaymentMintAuthorizerV1ZeroVerifyContract(address receiptVault, address owner)
@@ -112,7 +112,7 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1ConstructTest is Test {
             })
         );
         vm.expectRevert(ZeroVerifyContract.selector);
-        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.clone(address(implementation), initData));
+        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.cloneDeterministic(address(implementation), initData, bytes32(0)));
     }
 
     function testOffchainAssetReceiptVaultPaymentMintAuthorizerV1ZeroPaymentToken(address receiptVault, address owner)
@@ -131,7 +131,7 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1ConstructTest is Test {
             })
         );
         vm.expectRevert(ZeroPaymentToken.selector);
-        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.clone(address(implementation), initData));
+        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.cloneDeterministic(address(implementation), initData, bytes32(0)));
     }
 
     function testOffchainAssetReceiptVaultPaymentMintAuthorizerV1ZeroMaxSharesSupply(
@@ -153,7 +153,7 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1ConstructTest is Test {
             })
         );
         vm.expectRevert(ZeroMaxSharesSupply.selector);
-        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.clone(address(implementation), initData));
+        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.cloneDeterministic(address(implementation), initData, bytes32(0)));
     }
 
     function testOffchainAssetReceiptVaultPaymentMintAuthorizerV1Initialize(
@@ -204,7 +204,7 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1ConstructTest is Test {
             receiptVault, verify, owner, paymentToken, paymentTokenDecimals, maxSharesSupply
         );
         OffchainAssetReceiptVaultPaymentMintAuthorizerV1 authorizer =
-            OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.clone(address(implementation), initData));
+            OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.cloneDeterministic(address(implementation), initData, bytes32(0)));
         assertEq(authorizer.receiptVault(), receiptVault);
         assertEq(authorizer.paymentToken(), paymentToken);
         assertEq(authorizer.maxSharesSupply(), maxSharesSupply);

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.construct.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.construct.t.sol
@@ -70,7 +70,9 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1ConstructTest is Test {
             })
         );
         vm.expectRevert(ZeroReceiptVault.selector);
-        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.cloneDeterministic(address(implementation), initData, bytes32(0)));
+        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(
+            factory.cloneDeterministic(address(implementation), initData, bytes32(0))
+        );
     }
 
     function testOffchainAssetReceiptVaultPaymentMintAuthorizerV1ZeroInitialOwner(address receiptVault) external {
@@ -90,7 +92,9 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1ConstructTest is Test {
             })
         );
         vm.expectRevert(ZeroInitialOwner.selector);
-        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.cloneDeterministic(address(implementation), initData, bytes32(0)));
+        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(
+            factory.cloneDeterministic(address(implementation), initData, bytes32(0))
+        );
     }
 
     function testOffchainAssetReceiptVaultPaymentMintAuthorizerV1ZeroVerifyContract(address receiptVault, address owner)
@@ -112,7 +116,9 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1ConstructTest is Test {
             })
         );
         vm.expectRevert(ZeroVerifyContract.selector);
-        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.cloneDeterministic(address(implementation), initData, bytes32(0)));
+        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(
+            factory.cloneDeterministic(address(implementation), initData, bytes32(0))
+        );
     }
 
     function testOffchainAssetReceiptVaultPaymentMintAuthorizerV1ZeroPaymentToken(address receiptVault, address owner)
@@ -131,7 +137,9 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1ConstructTest is Test {
             })
         );
         vm.expectRevert(ZeroPaymentToken.selector);
-        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.cloneDeterministic(address(implementation), initData, bytes32(0)));
+        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(
+            factory.cloneDeterministic(address(implementation), initData, bytes32(0))
+        );
     }
 
     function testOffchainAssetReceiptVaultPaymentMintAuthorizerV1ZeroMaxSharesSupply(
@@ -153,7 +161,9 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1ConstructTest is Test {
             })
         );
         vm.expectRevert(ZeroMaxSharesSupply.selector);
-        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.cloneDeterministic(address(implementation), initData, bytes32(0)));
+        OffchainAssetReceiptVaultPaymentMintAuthorizerV1(
+            factory.cloneDeterministic(address(implementation), initData, bytes32(0))
+        );
     }
 
     function testOffchainAssetReceiptVaultPaymentMintAuthorizerV1Initialize(
@@ -203,8 +213,9 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1ConstructTest is Test {
         emit OffchainAssetReceiptVaultPaymentMintAuthorizerV1.Initialized(
             receiptVault, verify, owner, paymentToken, paymentTokenDecimals, maxSharesSupply
         );
-        OffchainAssetReceiptVaultPaymentMintAuthorizerV1 authorizer =
-            OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.cloneDeterministic(address(implementation), initData, bytes32(0)));
+        OffchainAssetReceiptVaultPaymentMintAuthorizerV1 authorizer = OffchainAssetReceiptVaultPaymentMintAuthorizerV1(
+            factory.cloneDeterministic(address(implementation), initData, bytes32(0))
+        );
         assertEq(authorizer.receiptVault(), receiptVault);
         assertEq(authorizer.paymentToken(), paymentToken);
         assertEq(authorizer.maxSharesSupply(), maxSharesSupply);

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.deposit.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.deposit.t.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.25;
 
 import {OffchainAssetReceiptVaultAuthorizerV1Test} from "test/abstract/OffchainAssetReceiptVaultAuthorizerV1Test.sol";
-import {CloneFactory} from "rain-factory-0.1.1/src/concrete/CloneFactory.sol";
+import {CloneFactory} from "rain-factory-0.1.5/src/concrete/CloneFactory.sol";
 import {
     OffchainAssetReceiptVaultPaymentMintAuthorizerV1,
     PaymentTokenDecimalMismatch,
@@ -42,7 +42,7 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1DepositTest is Offchain
                 maxSharesSupply: maxSharesSupply
             })
         );
-        return OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.clone(address(implementation), initData));
+        return OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.cloneDeterministic(address(implementation), initData, bytes32(0)));
     }
 
     function testMintSimpleRealReceiptVault(

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.deposit.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.deposit.t.sol
@@ -42,7 +42,9 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1DepositTest is Offchain
                 maxSharesSupply: maxSharesSupply
             })
         );
-        return OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.cloneDeterministic(address(implementation), initData, bytes32(0)));
+        return OffchainAssetReceiptVaultPaymentMintAuthorizerV1(
+            factory.cloneDeterministic(address(implementation), initData, bytes32(0))
+        );
     }
 
     function testMintSimpleRealReceiptVault(

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.ierc165.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.ierc165.t.sol
@@ -5,7 +5,7 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 
 import {IERC165} from "@openzeppelin-contracts-5.6.1/utils/introspection/IERC165.sol";
-import {ICloneableV2} from "rain-factory-0.1.1/src/interface/ICloneableV2.sol";
+import {ICloneableV2} from "rain-factory-0.1.5/src/interface/ICloneableV2.sol";
 import {IAuthorizeV1} from "src/interface/IAuthorizeV1.sol";
 import {
     OffchainAssetReceiptVaultPaymentMintAuthorizerV1

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.recipientNotOwner.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.recipientNotOwner.t.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.25;
 
 import {OffchainAssetReceiptVaultAuthorizerV1Test} from "test/abstract/OffchainAssetReceiptVaultAuthorizerV1Test.sol";
-import {CloneFactory} from "rain-factory-0.1.1/src/concrete/CloneFactory.sol";
+import {CloneFactory} from "rain-factory-0.1.5/src/concrete/CloneFactory.sol";
 import {
     OffchainAssetReceiptVaultPaymentMintAuthorizerV1,
     OffchainAssetReceiptVaultPaymentMintAuthorizerV1Config
@@ -24,7 +24,7 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1RecipientNotOwnerTest i
             new OffchainAssetReceiptVaultPaymentMintAuthorizerV1();
         CloneFactory factory = new CloneFactory();
         return OffchainAssetReceiptVaultPaymentMintAuthorizerV1(
-            factory.clone(
+            factory.cloneDeterministic(
                 address(implementation),
                 abi.encode(
                     OffchainAssetReceiptVaultPaymentMintAuthorizerV1Config({
@@ -34,7 +34,8 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1RecipientNotOwnerTest i
                         paymentToken: paymentToken,
                         maxSharesSupply: 1e27
                     })
-                )
+                ),
+                bytes32(0)
             )
         );
     }

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.sendPaymentToOwner.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.sendPaymentToOwner.t.sol
@@ -5,7 +5,7 @@ pragma solidity =0.8.25;
 import {OffchainAssetReceiptVaultAuthorizerV1Test} from "test/abstract/OffchainAssetReceiptVaultAuthorizerV1Test.sol";
 
 import {TestErc20} from "test/concrete/TestErc20.sol";
-import {CloneFactory} from "rain-factory-0.1.1/src/concrete/CloneFactory.sol";
+import {CloneFactory} from "rain-factory-0.1.5/src/concrete/CloneFactory.sol";
 import {IERC20Metadata} from "@openzeppelin-contracts-5.6.1/token/ERC20/extensions/IERC20Metadata.sol";
 import {
     OffchainAssetReceiptVaultPaymentMintAuthorizerV1
@@ -38,7 +38,7 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1IERC165Test is Offchain
         vm.mockCall(
             paymentToken, abi.encodeWithSelector(IERC20Metadata.decimals.selector), abi.encode(paymentTokenDecimals)
         );
-        return OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.clone(address(implementation), initData));
+        return OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.cloneDeterministic(address(implementation), initData, bytes32(0)));
     }
 
     function testSendPaymentToOwner(address receiptVault, address alice, address bob, address anon) external {

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.sendPaymentToOwner.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.sendPaymentToOwner.t.sol
@@ -38,7 +38,9 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1IERC165Test is Offchain
         vm.mockCall(
             paymentToken, abi.encodeWithSelector(IERC20Metadata.decimals.selector), abi.encode(paymentTokenDecimals)
         );
-        return OffchainAssetReceiptVaultPaymentMintAuthorizerV1(factory.cloneDeterministic(address(implementation), initData, bytes32(0)));
+        return OffchainAssetReceiptVaultPaymentMintAuthorizerV1(
+            factory.cloneDeterministic(address(implementation), initData, bytes32(0))
+        );
     }
 
     function testSendPaymentToOwner(address receiptVault, address alice, address bob, address anon) external {

--- a/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.verify.t.sol
+++ b/test/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.verify.t.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.25;
 
 import {OffchainAssetReceiptVaultAuthorizerV1Test} from "test/abstract/OffchainAssetReceiptVaultAuthorizerV1Test.sol";
-import {CloneFactory} from "rain-factory-0.1.1/src/concrete/CloneFactory.sol";
+import {CloneFactory} from "rain-factory-0.1.5/src/concrete/CloneFactory.sol";
 import {
     OffchainAssetReceiptVaultPaymentMintAuthorizerV1,
     OffchainAssetReceiptVaultPaymentMintAuthorizerV1Config,
@@ -36,7 +36,7 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1VerifyTest is OffchainA
             new OffchainAssetReceiptVaultPaymentMintAuthorizerV1();
         CloneFactory factory = new CloneFactory();
         return OffchainAssetReceiptVaultPaymentMintAuthorizerV1(
-            factory.clone(
+            factory.cloneDeterministic(
                 address(implementation),
                 abi.encode(
                     OffchainAssetReceiptVaultPaymentMintAuthorizerV1Config({
@@ -46,7 +46,8 @@ contract OffchainAssetReceiptVaultPaymentMintAuthorizerV1VerifyTest is OffchainA
                         paymentToken: paymentToken,
                         maxSharesSupply: 1e27
                     })
-                )
+                ),
+                bytes32(0)
             )
         );
     }

--- a/test/src/concrete/receipt/ERC20PriceOracleReceipt.metadata.t.sol
+++ b/test/src/concrete/receipt/ERC20PriceOracleReceipt.metadata.t.sol
@@ -26,7 +26,7 @@ contract ERC20PriceOracleReceiptMetadataTest is ReceiptFactoryTest {
         // Deploy the Receipt contract
         TestReceiptManager testManager = new TestReceiptManager();
         ERC20PriceOracleReceipt receipt = ERC20PriceOracleReceipt(
-            iFactory.clone(address(iErc20PriceOracleReceiptImplementation), abi.encode(address(testManager)))
+            cloneReceipt(address(iErc20PriceOracleReceiptImplementation), abi.encode(address(testManager)))
         );
 
         vm.expectRevert(ZeroReceiptId.selector);
@@ -39,7 +39,7 @@ contract ERC20PriceOracleReceiptMetadataTest is ReceiptFactoryTest {
         // Deploy the Receipt contract
         TestReceiptManager testManager = new TestReceiptManager();
         ERC20PriceOracleReceipt receipt = ERC20PriceOracleReceipt(
-            iFactory.clone(address(iErc20PriceOracleReceiptImplementation), abi.encode(address(testManager)))
+            cloneReceipt(address(iErc20PriceOracleReceiptImplementation), abi.encode(address(testManager)))
         );
 
         string memory uri = receipt.uri(id);
@@ -69,7 +69,7 @@ contract ERC20PriceOracleReceiptMetadataTest is ReceiptFactoryTest {
         // Deploy the Receipt contract
         TestReceiptManager testManager = new TestReceiptManager();
         ERC20PriceOracleReceipt receipt = ERC20PriceOracleReceipt(
-            iFactory.clone(address(iErc20PriceOracleReceiptImplementation), abi.encode(address(testManager)))
+            cloneReceipt(address(iErc20PriceOracleReceiptImplementation), abi.encode(address(testManager)))
         );
 
         assertEq(receipt.name(), "TRM Receipt");
@@ -79,7 +79,7 @@ contract ERC20PriceOracleReceiptMetadataTest is ReceiptFactoryTest {
         // Deploy the Receipt contract
         TestReceiptManager testManager = new TestReceiptManager();
         ERC20PriceOracleReceipt receipt = ERC20PriceOracleReceipt(
-            iFactory.clone(address(iErc20PriceOracleReceiptImplementation), abi.encode(address(testManager)))
+            cloneReceipt(address(iErc20PriceOracleReceiptImplementation), abi.encode(address(testManager)))
         );
 
         assertEq(receipt.symbol(), "TRM RCPT");

--- a/test/src/concrete/receipt/Receipt.metadata.t.sol
+++ b/test/src/concrete/receipt/Receipt.metadata.t.sol
@@ -11,7 +11,7 @@ contract ReceiptMetadataTest is ReceiptFactoryTest {
         // Deploy the Receipt contract
         TestReceiptManager testManager = new TestReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(testManager))));
 
         string memory uri = receipt.uri(id);
 
@@ -35,7 +35,7 @@ contract ReceiptMetadataTest is ReceiptFactoryTest {
         // Deploy the Receipt contract
         TestReceiptManager testManager = new TestReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(testManager))));
 
         assertEq(receipt.name(), "TRM Receipt");
     }
@@ -44,7 +44,7 @@ contract ReceiptMetadataTest is ReceiptFactoryTest {
         // Deploy the Receipt contract
         TestReceiptManager testManager = new TestReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(testManager))));
 
         assertEq(receipt.symbol(), "TRM RCPT");
     }

--- a/test/src/concrete/receipt/Receipt.msgSenderSpoof.t.sol
+++ b/test/src/concrete/receipt/Receipt.msgSenderSpoof.t.sol
@@ -29,7 +29,7 @@ contract ReceiptMsgSenderSpoofTest is ReceiptFactoryTest {
 
         TestReceiptManager testManager = new TestReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(testManager))));
 
         ApprovalSpoofReceiver maliciousReceiver = new ApprovalSpoofReceiver(IERC1155(address(receipt)), attacker);
 

--- a/test/src/concrete/receipt/Receipt.operatorIdentity.t.sol
+++ b/test/src/concrete/receipt/Receipt.operatorIdentity.t.sol
@@ -19,7 +19,7 @@ import {IERC1155} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155.sol
 contract ReceiptOperatorIdentityTest is ReceiptFactoryTest {
     function _setup() internal returns (SpyReceiptManager manager, ReceiptContract receipt) {
         manager = new SpyReceiptManager();
-        receipt = ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(manager))));
+        receipt = ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(manager))));
     }
 
     /// managerMint forwards the explicit `sender` as the authorization operator.

--- a/test/src/concrete/receipt/Receipt.operatorLeak.t.sol
+++ b/test/src/concrete/receipt/Receipt.operatorLeak.t.sol
@@ -19,7 +19,7 @@ import {IERC1155} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155.sol
 contract ReceiptOperatorLeakTest is ReceiptFactoryTest {
     function _setup(address privileged) internal returns (FreezeSimReceiptManager manager, ReceiptContract receipt) {
         manager = new FreezeSimReceiptManager(privileged);
-        receipt = ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(manager))));
+        receipt = ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(manager))));
     }
 
     /// The privileged operator does not leak into a re-entrant transfer. A mint

--- a/test/src/concrete/receipt/Receipt.receiptInformation.t.sol
+++ b/test/src/concrete/receipt/Receipt.receiptInformation.t.sol
@@ -28,7 +28,7 @@ contract ReceiptReceiptInformationTest is ReceiptFactoryTest {
 
         FreeTransferReceiptManager manager = new FreeTransferReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(manager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(manager))));
 
         vm.expectEmit(true, true, true, true);
         emit IReceiptV3.ReceiptInformation(depositor, id, data);
@@ -46,7 +46,7 @@ contract ReceiptReceiptInformationTest is ReceiptFactoryTest {
 
         SpyReceiptManager manager = new SpyReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(manager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(manager))));
 
         manager.mint(receipt, makeAddr("mintSender"), holder, id, amount, "");
 
@@ -64,7 +64,7 @@ contract ReceiptReceiptInformationTest is ReceiptFactoryTest {
 
         FreeTransferReceiptManager manager = new FreeTransferReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(manager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(manager))));
 
         vm.expectEmit(true, true, true, true);
         emit IReceiptV3.ReceiptInformation(alice, id, data);

--- a/test/src/concrete/receipt/Receipt.spoofEscalations.t.sol
+++ b/test/src/concrete/receipt/Receipt.spoofEscalations.t.sol
@@ -24,7 +24,7 @@ import {IERC1155Errors} from "@openzeppelin-contracts-5.6.1/interfaces/draft-IER
 contract ReceiptSpoofEscalationsTest is ReceiptFactoryTest {
     function _setup() internal returns (FreeTransferReceiptManager manager, ReceiptContract receipt) {
         manager = new FreeTransferReceiptManager();
-        receipt = ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(manager))));
+        receipt = ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(manager))));
     }
 
     /// E1 (neutralized): the atomic same-tx drain of the victim's pre-existing
@@ -175,7 +175,7 @@ contract ReceiptSpoofEscalationsTest is ReceiptFactoryTest {
 
         SpyReceiptManager manager = new SpyReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(manager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(manager))));
         address from = makeAddr("from");
         address confiscator = makeAddr("confiscator");
         address attacker = makeAddr("attacker");

--- a/test/src/concrete/receipt/Receipt.storageLayout.t.sol
+++ b/test/src/concrete/receipt/Receipt.storageLayout.t.sol
@@ -22,7 +22,7 @@ contract ReceiptStorageLayoutTest is ReceiptFactoryTest {
 
     function _setup() internal returns (SpyReceiptManager manager, ReceiptContract receipt) {
         manager = new SpyReceiptManager();
-        receipt = ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(manager))));
+        receipt = ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(manager))));
     }
 
     /// `manager` is stored at the base slot (`RECEIPT_STORAGE_LOCATION`).

--- a/test/src/concrete/receipt/Receipt.t.sol
+++ b/test/src/concrete/receipt/Receipt.t.sol
@@ -13,7 +13,7 @@ contract ReceiptTest is ReceiptFactoryTest {
     function testInitialize() public {
         TestReceiptManager testManager = new TestReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(testManager))));
         assertEq(receipt.manager(), address(testManager));
     }
 
@@ -25,7 +25,7 @@ contract ReceiptTest is ReceiptFactoryTest {
 
         TestReceiptManager testManager = new TestReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(testManager))));
 
         vm.startPrank(alice);
 
@@ -41,7 +41,7 @@ contract ReceiptTest is ReceiptFactoryTest {
 
         TestReceiptManager testManager = new TestReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(testManager))));
 
         vm.startPrank(alice);
 
@@ -63,7 +63,7 @@ contract ReceiptTest is ReceiptFactoryTest {
 
         TestReceiptManager testManager = new TestReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(testManager))));
 
         vm.startPrank(alice);
 
@@ -82,7 +82,7 @@ contract ReceiptTest is ReceiptFactoryTest {
 
         TestReceiptManager testManager = new TestReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(testManager))));
 
         vm.startPrank(alice);
 
@@ -122,7 +122,7 @@ contract ReceiptTest is ReceiptFactoryTest {
 
         TestReceiptManager testManager = new TestReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(testManager))));
 
         vm.startPrank(alice);
 
@@ -158,7 +158,7 @@ contract ReceiptTest is ReceiptFactoryTest {
 
         TestReceiptManager testManager = new TestReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(testManager))));
 
         vm.startPrank(alice);
 
@@ -192,7 +192,7 @@ contract ReceiptTest is ReceiptFactoryTest {
 
         TestReceiptManager testManager = new TestReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(testManager))));
 
         vm.startPrank(alice);
 
@@ -222,7 +222,7 @@ contract ReceiptTest is ReceiptFactoryTest {
 
         TestReceiptManager testManager = new TestReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(testManager))));
 
         vm.startPrank(alice);
 
@@ -246,7 +246,7 @@ contract ReceiptTest is ReceiptFactoryTest {
 
         TestReceiptManager testManager = new TestReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(testManager))));
 
         vm.startPrank(alice);
 
@@ -275,7 +275,7 @@ contract ReceiptTest is ReceiptFactoryTest {
 
         TestReceiptManager testManager = new TestReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(testManager))));
 
         vm.startPrank(alice);
 
@@ -310,7 +310,7 @@ contract ReceiptTest is ReceiptFactoryTest {
 
         TestReceiptManager testManager = new TestReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(testManager))));
 
         vm.startPrank(alice);
 
@@ -345,7 +345,7 @@ contract ReceiptTest is ReceiptFactoryTest {
         vm.assume(alice != bob);
 
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(alice))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(alice))));
 
         vm.startPrank(alice);
         // Alice approves operator
@@ -367,7 +367,7 @@ contract ReceiptTest is ReceiptFactoryTest {
 
         TestReceiptManager testManager = new TestReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(testManager))));
 
         vm.startPrank(alice);
 
@@ -426,7 +426,7 @@ contract ReceiptTest is ReceiptFactoryTest {
         // Create a new receipt
         TestReceiptManager testManager = new TestReceiptManager();
         ReceiptContract receipt =
-            ReceiptContract(iFactory.clone(address(iReceiptImplementation), abi.encode(address(testManager))));
+            ReceiptContract(cloneReceipt(address(iReceiptImplementation), abi.encode(address(testManager))));
 
         vm.startPrank(alice);
 


### PR DESCRIPTION
Bumps the `rain-factory` dependency 0.1.1 → 0.1.5 and migrates `rain.vats` onto the current rainix-autopublish next-version convention, so a rain-factory-0.1.5-based `rain-vats 0.1.7` gets published.

## What

- **`rain-factory` 0.1.1 → 0.1.5** in `foundry.toml` + the 4 imports that reference it (`ReceiptVault.sol`, `OffchainAssetReceiptVaultAuthorizerV1.sol`, `OffchainAssetReceiptVaultPaymentMintAuthorizerV1.sol`, `Receipt.sol`). Every one imports only `{ICloneableV2, ICLONEABLE_V2_SUCCESS}` — the cloneable-*contract* interface — which is byte-identical across 0.1.1..0.1.5. With `bytecode_hash = "none"` + `cbor_metadata = false` the bump is **bytecode-neutral** (no redeploy of any consumer).
- **`[package].version` 0.1.6 → 0.1.7.** 0.1.6 was already the latest published revision, but `package-release.yaml` uses `rainix-autopublish.yaml@main`, whose next-version lifecycle requires `[package].version` to be the NEXT, *unpublished* version (the soldeer-gate enforces in-dev > published). rain.vats had drifted onto the old "version == latest-published" state; this migrates it back onto the convention so the rain-factory content change publishes as 0.1.7.
- `soldeer.lock` + `remappings.txt` regenerated for the new pin.

## Why

`rain.vats` only ever consumed rain-factory for the stable `ICloneableV2` interface — it does not clone anything. Meanwhile `st0x.deploy` needs rain-factory **0.1.5**'s `CloneFactory.cloneDeterministic` for a deterministic V4-authoriser clone, but the tree was pinned to 0.1.1 *through rain.vats*, forcing a two-version conflict. Moving rain.vats to 0.1.5 collapses the tree to a **single** rain-factory version so st0x can consume it cleanly.

## Downstream

Once 0.1.7 publishes, st0x.deploy bumps `rain-vats` 0.1.6 → 0.1.7 (single rain-factory 0.1.5), unblocking https://github.com/S01-Issuer/st0x.deploy/pull/250.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project release version to 0.1.7.
  - Updated the Rain Factory dependency to version 0.1.5.
  - Refreshed dependency references across receipt and authorization components.
  - No user-facing functionality or contract behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->